### PR TITLE
Fix peer-link parsing regex

### DIFF
--- a/pyeapi/api/mlag.py
+++ b/pyeapi/api/mlag.py
@@ -158,7 +158,7 @@ class Mlag(Entity):
             dict: A dict object that is intended to be merged into the
                 resource dict
         """
-        match = re.search(r'peer-link (\w+)', config)
+        match = re.search(r'peer-link (\S+)', config)
         value = match.group(1) if match else None
         return dict(peer_link=value)
 
@@ -289,4 +289,3 @@ def instance(node):
         object: An instance of Mlag
     """
     return Mlag(node)
-

--- a/test/system/test_api_mlag.py
+++ b/test/system/test_api_mlag.py
@@ -142,6 +142,15 @@ class TestApiMlag(DutSystemTest):
             self.assertTrue(result)
             self.assertIn('peer-link Ethernet1', api.get_block('mlag configuration'))
 
+    def test_set_peer_link_with_value_portchannel(self):
+        for dut in self.duts:
+            dut.config(['default mlag configuration','interface Port-Channel5'])
+            api = dut.api('mlag')
+            self.assertIn('no peer-link', api.get_block('mlag configuration'))
+            result = dut.api('mlag').set_peer_link('Port-Channel5')
+            self.assertTrue(result)
+            self.assertIn('peer-link Port-Channel5', api.get_block('mlag configuration'))
+
     def test_set_peer_link_with_no_value(self):
         for dut in self.duts:
             dut.config(['mlag configuration', 'peer-link Ethernet1'])

--- a/test/system/test_api_stp.py
+++ b/test/system/test_api_stp.py
@@ -49,7 +49,7 @@ class TestApiStpInterfaces(DutSystemTest):
 
     def test_getall(self):
         for dut in self.duts:
-            dut.config('default interface Et1-7')
+            dut.config('default interface Et1-4')
             result = dut.api('stp').interfaces.getall()
             self.assertIsInstance(result, dict)
 


### PR DESCRIPTION
- Fix #24
- Add testcases to set port-channel for peer-link
- Change stp test to not use et1-7, just et1-4