### PR TITLE
Add sshkey support to users API

### DIFF
--- a/pyeapi/api/users.py
+++ b/pyeapi/api/users.py
@@ -74,13 +74,18 @@ def isprivilege(value):
 
 
 class Users(EntityCollection):
-    """The Users class provides a configuration resource for local users
+    """The Users class provides a configuration resource for local users.
+    The regex used here parses the running configuration to find username
+    entries. There is extra logic in the regular expression to store
+    the username as 'user' and then creates a backreference to find a
+    following configuration line that might contain the users sshkey.
     """
 
-    users_re = re.compile(r'username ([^\s]+) privilege (\d+)'
+    users_re = re.compile(r'username (?P<user>[^\s]+) privilege (\d+)'
                           r'(?: role ([^\s]+))?'
                           r'(?: (nopassword))?'
-                          r'(?: secret (0|5|7|sha512) (.+))?', re.M)
+                          r'(?: secret (0|5|7|sha512) (.+))?'
+                          r'.*$\n(?:username (?P=user) sshkey (.+)$)?', re.M)
 
     def get(self, name):
         """Returns the local user configuration as a resource dict
@@ -122,13 +127,14 @@ class Users(EntityCollection):
             dict: A resource dict that is intended to be merged into the
                 user resource
         """
-        (username, priv, role, nopass, fmt, secret) = config
+        (username, priv, role, nopass, fmt, secret, sshkey) = config
         resource = dict()
         resource['privilege'] = priv
         resource['role'] = role
         resource['nopassword'] = nopass == 'nopassword'
         resource['format'] = fmt
         resource['secret'] = secret
+        resource['sshkey'] = sshkey
         return {username: resource}
 
     def create(self, name, nopassword=None, secret=None, encryption=None):
@@ -243,7 +249,7 @@ class Users(EntityCollection):
                 raise TypeError('priviledge value must be between 0 and 15')
             cmd += ' privilege %s' % value
         else:
-            cmd += ' no privilege'
+            cmd += ' privilege 1'
         return self.configure(cmd)
 
     def set_role(self, name, value=None):
@@ -261,9 +267,26 @@ class Users(EntityCollection):
         if value is not None:
             cmd += ' role %s' % value
         else:
-            cmd += ' no role'
+            cmd = 'default username %s role' % name
         return self.configure(cmd)
 
+    def set_sshkey(self, name, value=None):
+        """Configures the user sshkey
+
+        Args:
+            name (str): The name of the user to add the sshkey to
+
+            value (str): The value to configure for the sshkey.
+
+        Returns:
+            True if the operation was successful otherwise False
+        """
+        cmd = 'username %s' % name
+        if value is not None:
+            cmd += ' sshkey %s' % value
+        else:
+            cmd = 'no username %s sshkey' % name
+        return self.configure(cmd)
 
 def instance(node):
     """Returns an instance of Users
@@ -277,4 +300,3 @@ def instance(node):
             resource
     """
     return Users(node)
-

--- a/pyeapi/api/users.py
+++ b/pyeapi/api/users.py
@@ -282,7 +282,7 @@ class Users(EntityCollection):
             True if the operation was successful otherwise False
         """
         cmd = 'username %s' % name
-        if value is not None:
+        if value:
             cmd += ' sshkey %s' % value
         else:
             cmd = 'no username %s sshkey' % name

--- a/test/system/test_api_users.py
+++ b/test/system/test_api_users.py
@@ -144,6 +144,26 @@ class TestApiUsers(DutSystemTest):
             self.assertTrue(result)
             self.assertIn('username test sshkey %s' % TEST_SSH_KEY, api.config)
 
+    def test_set_sshkey_with_empty_string(self):
+        for dut in self.duts:
+            dut.config(['no username test', 'username test nopassword'])
+            api = dut.api('users')
+            self.assertIn('username test privilege 1 nopassword', api.config)
+            self.assertNotIn('username test sshkey', api.config)
+            result = api.set_sshkey('test', '')
+            self.assertTrue(result)
+            self.assertNotIn('username test sshkey %s' % TEST_SSH_KEY, api.config)
+
+    def test_set_sshkey_with_None(self):
+        for dut in self.duts:
+            dut.config(['no username test', 'username test nopassword'])
+            api = dut.api('users')
+            self.assertIn('username test privilege 1 nopassword', api.config)
+            self.assertNotIn('username test sshkey', api.config)
+            result = api.set_sshkey('test', None)
+            self.assertTrue(result)
+            self.assertNotIn('username test sshkey %s' % TEST_SSH_KEY, api.config)
+
     def test_set_sshkey_with_no_value(self):
         for dut in self.duts:
             dut.config(['no username test',

--- a/test/system/test_api_users.py
+++ b/test/system/test_api_users.py
@@ -37,15 +37,25 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '../lib'))
 
 from systestlib import DutSystemTest
 
+TEST_SSH_KEY = ('ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKL1UtBALa4CvFUsHUipNym'
+                'A04qCXuAtTwNcMj84bTUzUI+q7mdzRCTLkllXeVxKuBnaTm2PW7W67K5CVpl0'
+                'EVCm6IY7FS7kc4nlnD/tFvTvShy/fzYQRAdM7ZfVtegW8sMSFJzBR/T/Y/sxI'
+                '16Y/dQb8fC3la9T25XOrzsFrQiKRZmJGwg8d+0RLxpfMg0s/9ATwQKp6tPoLE'
+                '4f3dKlAgSk5eENyVLA3RsypWADHpenHPcB7sa8D38e1TS+n+EUyAdb3Yov+5E'
+                'SAbgLIJLd52Xv+FyYi0c2L49ByBjcRrupp4zfXn4DNRnEG4K6GcmswHuMEGZv'
+                '5vjJ9OYaaaaaaa')
 
 class TestApiUsers(DutSystemTest):
 
     def test_get(self):
         for dut in self.duts:
-            dut.config(['no username test', 'username test nopassword'])
+            dut.config(['no username test', 'username test nopassword',
+                        'username test sshkey %s' % TEST_SSH_KEY])
+
             result = dut.api('users').get('test')
             values = dict(nopassword=True, privilege='1', secret='',
-                          role='', format='')
+                          role='', format='',
+                          sshkey=TEST_SSH_KEY)
 
             result = self.sort_dict_by_keys(result)
             values = self.sort_dict_by_keys(values)
@@ -85,16 +95,17 @@ class TestApiUsers(DutSystemTest):
             self.assertTrue(result)
             self.assertNotIn('username test nopassword', api.config)
 
-    def set_privilege_with_value(self):
+    def test_set_privilege_with_value(self):
         for dut in self.duts:
             dut.config(['no username test', 'username test nopassword'])
             api = dut.api('users')
-            self.assertIn('username test nopassword', api.config)
+            # EOS defaults to privilege 1
+            self.assertIn('username test privilege 1 nopassword', api.config)
             result = api.set_privilege('test', 8)
             self.assertTrue(result)
-            self.assertNotIn('username test privilege 8', api.config)
+            self.assertIn('username test privilege 8 nopassword', api.config)
 
-    def set_privilege_with_no_value(self):
+    def test_set_privilege_with_no_value(self):
         for dut in self.duts:
             dut.config(['no username test',
                         'username test privilege 8 nopassword'])
@@ -102,8 +113,47 @@ class TestApiUsers(DutSystemTest):
             self.assertIn('username test privilege 8', api.config)
             result = api.set_privilege('test')
             self.assertTrue(result)
-            self.assertNotIn('username test privilege 1', api.config)
+            self.assertIn('username test privilege 1', api.config)
 
+    def test_set_role_with_value(self):
+        for dut in self.duts:
+            dut.config(['no username test', 'username test nopassword'])
+            api = dut.api('users')
+            self.assertIn('username test privilege 1 nopassword', api.config)
+            result = api.set_role('test', 'network-admin')
+            self.assertTrue(result)
+            self.assertIn('username test privilege 1 role network-admin nopassword', api.config)
+
+    def test_set_role_with_no_value(self):
+        for dut in self.duts:
+            dut.config(['no username test',
+                        'username test role network-admin nopassword'])
+            api = dut.api('users')
+            self.assertIn('username test privilege 1 role network-admin nopassword', api.config)
+            result = api.set_role('test')
+            self.assertTrue(result)
+            self.assertNotIn('username test privilege 1 role network-admin nopassword', api.config)
+
+    def test_set_sshkey_with_value(self):
+        for dut in self.duts:
+            dut.config(['no username test', 'username test nopassword'])
+            api = dut.api('users')
+            self.assertIn('username test privilege 1 nopassword', api.config)
+            self.assertNotIn('username test sshkey', api.config)
+            result = api.set_sshkey('test', TEST_SSH_KEY)
+            self.assertTrue(result)
+            self.assertIn('username test sshkey %s' % TEST_SSH_KEY, api.config)
+
+    def test_set_sshkey_with_no_value(self):
+        for dut in self.duts:
+            dut.config(['no username test',
+                        'username test nopassword'])
+            api = dut.api('users')
+            self.assertIn('username test privilege 1 nopassword', api.config)
+            result = api.set_sshkey('test')
+            self.assertTrue(result)
+            self.assertNotIn('username test sshkey %s' % TEST_SSH_KEY,
+                             api.config)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/unit/test_api_users.py
+++ b/test/unit/test_api_users.py
@@ -52,7 +52,7 @@ class TestApiUsers(EapiConfigUnitTest):
         self.assertFalse(result)
 
     def test_get(self):
-        keys = ['nopassword', 'privilege', 'role', 'secret', 'format']
+        keys = ['nopassword', 'privilege', 'role', 'secret', 'format', 'sshkey']
         result = self.instance.get('test')
         self.assertEqual(sorted(keys), sorted(result.keys()))
 
@@ -123,12 +123,5 @@ class TestApiUsers(EapiConfigUnitTest):
         self.eapi_positive_config_test(func, cmds)
 
 
-
-
-
-
-
 if __name__ == '__main__':
     unittest.main()
-
-

--- a/test/unit/test_api_users.py
+++ b/test/unit/test_api_users.py
@@ -104,7 +104,7 @@ class TestApiUsers(EapiConfigUnitTest):
         self.eapi_positive_config_test(func, cmds)
 
     def test_set_privilege_negate(self):
-        cmds = 'username test no privilege'
+        cmds = 'username test privilege 1'
         func = function('set_privilege', 'test')
         self.eapi_positive_config_test(func, cmds)
 
@@ -118,7 +118,7 @@ class TestApiUsers(EapiConfigUnitTest):
         self.eapi_positive_config_test(func, cmds)
 
     def test_set_role_negate(self):
-        cmds = 'username test no role'
+        cmds = 'default username test role'
         func = function('set_role', 'test')
         self.eapi_positive_config_test(func, cmds)
 


### PR DESCRIPTION
- Close #31 - Adding support for sshkeys
- Fix #32 - set_privilege tests
- Fix #33 - set_role test tests

Note that there were no system tests for set_role.  Also, the system tests for set_privilege weren't prefixed with test_ so they were never run.