### PR TITLE
Close #46

### DIFF
--- a/pyeapi/api/interfaces.py
+++ b/pyeapi/api/interfaces.py
@@ -590,7 +590,7 @@ class PortchannelInterface(BaseInterface):
         return re.findall(r'\b(?!Peer)Ethernet[\d/]*\b',
                           config[0]['result']['output'])
 
-    def set_members(self, name, members):
+    def set_members(self, name, members, mode=None):
         """Configures the array of member interfaces for the Port-Channel
 
         Args:
@@ -600,11 +600,17 @@ class PortchannelInterface(BaseInterface):
             members(list): The list of Ethernet interfaces that should be
                 member interfaces
 
+            mode(str): The LACP mode to configure the member interfaces to.
+                Valid values are 'on, 'passive', 'active'
+
         Returns:
             True if the operation succeeds otherwise False
         """
         current_members = self.get_members(name)
-        lacp_mode = self.get_lacp_mode(name)
+        if mode:
+            lacp_mode = mode
+        else:
+            lacp_mode = self.get_lacp_mode(name)
         grpid = re.search(r'(\d+)', name).group()
 
         commands = list()

--- a/pyeapi/api/interfaces.py
+++ b/pyeapi/api/interfaces.py
@@ -108,7 +108,7 @@ class Interfaces(EntityCollection):
         for name in interfaces_re.findall(self.config):
             interface = self.get(name)
             if interface:
-                response[name] = interface
+                response['name'] = interface
         return response
 
     def __getattr__(self, name):
@@ -171,7 +171,6 @@ class BaseInterface(EntityCollection):
         resource.update(self._parse_shutdown(config))
         resource.update(self._parse_description(config))
         return resource
-
 
     def _parse_shutdown(self, config):
         """Scans the specified config block and returns the shutdown value
@@ -334,7 +333,6 @@ class EthernetInterface(BaseInterface):
         resource.update(self._parse_flowcontrol_receive(config))
         return resource
 
-
     def _parse_sflow(self, config):
         """Scans the specified config block and returns the sflow value
 
@@ -382,7 +380,6 @@ class EthernetInterface(BaseInterface):
         if match:
             value = match.group(1)
         return dict(flowcontrol_receive=value)
-
 
     def create(self, name):
         """Creating Ethernet interfaces is currently not supported
@@ -549,7 +546,6 @@ class PortchannelInterface(BaseInterface):
             value = int(match.group(1))
         return dict(minimum_links=value)
 
-
     def get_lacp_mode(self, name):
         """Returns the LACP mode for the specified Port-Channel interface
 
@@ -570,8 +566,6 @@ class PortchannelInterface(BaseInterface):
             match = re.search(r'channel-group\s\d+\smode\s(?P<value>.+)',
                               self.get_block('^interface %s' % member))
             return match.group('value')
-
-
 
     def get_members(self, name):
         """Returns the member interfaces for the specified Port-Channel

--- a/pyeapi/api/interfaces.py
+++ b/pyeapi/api/interfaces.py
@@ -617,15 +617,7 @@ class PortchannelInterface(BaseInterface):
         lacp_mode = self.get_lacp_mode(name)
         if mode and mode != lacp_mode:
             lacp_mode = mode
-            # remove all members from the current port-channel interface
-            # so that we can change the mode below
-            for member in current_members:
-                commands.append('interface %s' % member)
-                commands.append('no channel-group %s' % grpid)
-            # add all members back with the specified lacp_mode
-            for member in current_members:
-                commands.append('interface %s' % member)
-                commands.append('channel-group %s mode %s' % (grpid, lacp_mode))
+            self.set_lacp_mode(grpid, lacp_mode)
 
         # remove members from the current port-channel interface
         for member in set(current_members).difference(members):

--- a/test/unit/test_api_interfaces.py
+++ b/test/unit/test_api_interfaces.py
@@ -303,6 +303,27 @@ class TestApiPortchannelInterface(EapiConfigUnitTest):
                         ['Ethernet5', 'Ethernet7'])
         self.eapi_positive_config_test(func, cmds)
 
+    def test_set_members_same_mode(self):
+        cmds = ['interface Ethernet6', 'no channel-group 1',
+                'interface Ethernet7', 'channel-group 1 mode on']
+        func = function('set_members', 'Port-Channel1',
+                        ['Ethernet5', 'Ethernet7'])
+        self.eapi_positive_config_test(func, cmds)
+
+    def test_set_members_update_mode(self):
+        cmds = ['interface Ethernet6', 'no channel-group 1',
+                'interface Ethernet7', 'channel-group 1 mode active']
+        func = function('set_members', 'Port-Channel1',
+                        ['Ethernet5', 'Ethernet7'], mode='active')
+        self.eapi_positive_config_test(func, cmds)
+
+    def test_set_members_mode_none(self):
+        cmds = ['interface Ethernet6', 'no channel-group 1',
+                'interface Ethernet7', 'channel-group 1 mode on']
+        func = function('set_members', 'Port-Channel1',
+                        ['Ethernet5', 'Ethernet7'], mode=None)
+        self.eapi_positive_config_test(func, cmds)
+
     def test_set_members_no_changes(self):
         func = function('set_members', 'Port-Channel1',
                         ['Ethernet5', 'Ethernet6'])
@@ -410,5 +431,3 @@ class TestApiVxlanInterface(EapiConfigUnitTest):
 
 if __name__ == '__main__':
     unittest.main()
-
-

--- a/test/unit/test_api_interfaces.py
+++ b/test/unit/test_api_interfaces.py
@@ -77,6 +77,10 @@ class TestApiInterfaces(EapiConfigUnitTest):
         result = self.instance.get('Ethernet1')
         self.assertEqual(result['type'], 'ethernet')
 
+    def test_get_invalid_interface(self):
+        result = self.instance.get('Foo1')
+        self.assertEqual(result, None)
+
     def test_proxy_method_success(self):
         result = self.instance.set_sflow('Ethernet1', True)
         self.assertTrue(result)


### PR DESCRIPTION
- This commit adds a 'mode' keyword argument to the set_members method. The
set_members method already looks to get the lacp_mode in use from existing
members but ultimately uses 'on' if no other members exist. This commit
allows you to supercede that pass in the desired lacp mode.