### PR TITLE
Making configure RADIUS compatible

### DIFF
--- a/pyeapi/client.py
+++ b/pyeapi/client.py
@@ -504,7 +504,7 @@ class Node(object):
         commands = list(commands)
 
         # push the configure command onto the command stack
-        commands.insert(0, 'configure')
+        commands.insert(0, 'configure terminal')
         response = self.run_commands(commands)
 
         if self.autorefresh:


### PR DESCRIPTION
* The RBAC and RADIUS compatibility do not allow short notations of
 command. Hence elongating to full command.