### PR TITLE
Fix for redmine issues 234 and 268

### DIFF
--- a/pyeapi/api/abstract.py
+++ b/pyeapi/api/abstract.py
@@ -81,8 +81,8 @@ class BaseEntity(object):
         Args:
             parent (str): The parent string to search the config for and
                 return the block
-            config (str): A text string config to be searched. A value of
-                None will search the running-config of the Node.
+            config (str): A text config string to be searched. Default
+                is to search the running-config of the Node.
 
         Returns:
             A string object that represents the block from the config.  If

--- a/pyeapi/api/abstract.py
+++ b/pyeapi/api/abstract.py
@@ -75,12 +75,14 @@ class BaseEntity(object):
     def error(self):
         return self.node.connection.error
 
-    def get_block(self, parent):
+    def get_block(self, parent, config='running_config'):
         """ Scans the config and returns a block of code
 
         Args:
             parent (str): The parent string to search the config for and
                 return the block
+            config (str): A text string config to be searched. A value of
+                None will search the running-config of the Node.
 
         Returns:
             A string object that represents the block from the config.  If
@@ -90,7 +92,7 @@ class BaseEntity(object):
         """
         try:
             parent = r'^%s$' % parent
-            return self.node.section(parent)
+            return self.node.section(parent, config=config)
         except TypeError:
             return None
 

--- a/pyeapi/client.py
+++ b/pyeapi/client.py
@@ -536,7 +536,8 @@ class Node(object):
         Returns:
             The configuration section as a string object.
         """
-        config = getattr(self, config)
+        if config in ['running_config', 'startup_config']:
+            config = getattr(self, config)
         match = re.search(regex, config, re.M)
         if not match:
             raise TypeError('config section not found')

--- a/test/system/test_client.py
+++ b/test/system/test_client.py
@@ -95,6 +95,22 @@ class TestClient(unittest.TestCase):
                 self.assertIsInstance(result, list, 'dut=%s' % dut)
                 self.assertEqual(len(result), 1, 'dut=%s' % dut)
 
+    def test_get_block(self):
+        # Verify get_block using a config string returns correct value
+        for dut in self.duts:
+            api = dut.api('interfaces')
+            config = api.config
+            running = api.get_block('interface Ethernet1')
+            txtstr = api.get_block('interface Ethernet1', config=config)
+            self.assertEqual(running, txtstr)
+
+    def test_get_block_none(self):
+        # Verify get_block using a config string where match fails returns None
+        for dut in self.duts:
+            api = dut.api('interfaces')
+            txtstr = api.get_block('interface Ethernet1', config='config')
+            self.assertEqual(txtstr, None)
+
 
 class TestNode(unittest.TestCase):
 


### PR DESCRIPTION
234: Refactor interfaces system tests - reorder tests so grouping makes a little more sense, add default and negate tests for set_description
268: Allow a config string to be passed to abstract.get_block for searching. defaults to 'running_config' which compares to node's running-config
