### PR TITLE
Redmine issue 648

### DIFF
--- a/pyeapi/api/bgp.py
+++ b/pyeapi/api/bgp.py
@@ -162,7 +162,8 @@ class Bgp(Entity):
 
     def add_network(self, prefix, length, route_map=None):
         if prefix == '' or length == '':
-            raise ValueError('network prefix/length values may not be null')
+            raise ValueError('network prefix and length values '
+                             'may not be empty')
         cmd = 'network {}/{}'.format(prefix, length)
         if route_map:
             cmd += ' route-map {}'.format(route_map)
@@ -170,7 +171,8 @@ class Bgp(Entity):
 
     def remove_network(self, prefix, masklen, route_map=None):
         if prefix == '' or masklen == '':
-            raise ValueError('network prefix/masklen values may not be null')
+            raise ValueError('network prefix and length values '
+                             'may not be empty')
         cmd = 'no network {}/{}'.format(prefix, masklen)
         if route_map:
             cmd += ' route-map {}'.format(route_map)

--- a/pyeapi/api/bgp.py
+++ b/pyeapi/api/bgp.py
@@ -161,12 +161,16 @@ class Bgp(Entity):
         return self.configure_bgp(cmd)
 
     def add_network(self, prefix, length, route_map=None):
+        if prefix == '' or length == '':
+            raise ValueError('network prefix/length values may not be null')
         cmd = 'network {}/{}'.format(prefix, length)
         if route_map:
             cmd += ' route-map {}'.format(route_map)
         return self.configure_bgp(cmd)
 
     def remove_network(self, prefix, masklen, route_map=None):
+        if prefix == '' or masklen == '':
+            raise ValueError('network prefix/masklen values may not be null')
         cmd = 'no network {}/{}'.format(prefix, masklen)
         if route_map:
             cmd += ' route-map {}'.format(route_map)

--- a/test/unit/test_api_bgp.py
+++ b/test/unit/test_api_bgp.py
@@ -80,10 +80,22 @@ class TestApiBgp(EapiConfigUnitTest):
         cmds = ['router bgp 65000', 'network 172.16.10.1/24 route-map test']
         self.eapi_positive_config_test(func, cmds)
 
+        func = function('add_network', '', '24', 'test')
+        self.eapi_exception_config_test(func, ValueError)
+
+        func = function('add_network', '172.16.10.1', '', 'test')
+        self.eapi_exception_config_test(func, ValueError)
+
     def test_remove_network(self):
         func = function('remove_network', '172.16.10.1', '24', 'test')
         cmds = ['router bgp 65000', 'no network 172.16.10.1/24 route-map test']
         self.eapi_positive_config_test(func, cmds)
+
+        func = function('remove_network', '', '24', 'test')
+        self.eapi_exception_config_test(func, ValueError)
+
+        func = function('remove_network', '172.16.10.1', '', 'test')
+        self.eapi_exception_config_test(func, ValueError)
 
     def test_set_router_id(self):
         for state in ['config', 'negate', 'default']:


### PR DESCRIPTION
Make sure empty string handling is correct.

Most methods utilize the command_builder method for creating the command string, which currently interprets the empty string as a negation command. In this case, empty strings do produce a valid command.

The bgp module methods add/remove_network do not use the command_builder method, but build the command internally. This was the only instance where validation of input was required.