### PR TITLE
Added support for multiline commands without having to pass them as a dictionary

### DIFF
--- a/pyeapi/client.py
+++ b/pyeapi/client.py
@@ -637,6 +637,14 @@ class Node(object):
         """
         commands = make_iterable(commands)
 
+        # Some commands are multiline commands. These are banner commands and SSL commands. So with this two lines we
+        # can support those by passing commands by doing:
+        # banner login MULTILINE: This is my banner.\nAnd I even support multiple lines.
+        # Why this? To be able to read a configuration from a file, split it into lines and pass it as it is
+        # to pyeapi without caring about multiline commands.
+        commands = [{'cmd': c.split('MULTILINE:')[0], 'input': c.split('MULTILINE:')[1]}
+                    if 'MULTILINE:' in c else c for c in commands]
+
         if self._enablepwd:
             commands.insert(0, {'cmd': 'enable', 'input': self._enablepwd})
         else:


### PR DESCRIPTION
We usually generate full configurations with jinja2 templates and pass them directly to the pyeapi without further processing (we do it via napalm as we have an environment with multiple vendors). The problem comes when we try to execute what you seem to call 'multiline' commands. This PR addresses this problem so you can do something like this:

    >>> import pyeapi
    >>> connection = pyeapi.client.connect(
    ...     transport='https',
    ...     host='192.168.56.201',
    ...     username='vagrant',
    ...     password='vagrant',
    ...     port=443,
    ...     timeout=60
    ... )
    >>> device = pyeapi.client.Node(connection)
    >>> device.run_commands('show hostname')
    [{u'hostname': u'localhost', u'fqdn': u'localhost'}]
    >>> device.run_commands('show banner login')
    [{u'loginBanner': u''}]
    >>> my_commands = [
    ...     'configure session whatever',
    ...     'hostname new-hostname',
    ...     'banner login MULTILINE:This is a new banner\nwith different lines!!!',
    ...     'end'
    ... ]
    >>>
    >>> device.run_commands(my_commands)
    [{}, {}, {}, {}]
    >>> print device.run_commands(['show session-config named whatever diffs'], encoding='text')[0]['output']
    --- system:/running-config
    +++ session:/whatever-session-config
    @@ -3,6 +3,8 @@
     ! boot system flash:/vEOS-lab.swi
     !
     transceiver qsfp default-mode 4x10G
    +!
    +hostname new-hostname
     !
     spanning-tree mode mstp
     !
    @@ -22,6 +24,11 @@
     !
     no ip routing
     !
    +banner login
    +This is a new banner
    +with different lines!!!
    +EOF
    +!
     management api http-commands
        no shutdown
     !
    >>> device.run_commands(['configure session whatever', 'commit'])
    [{}, {}]
    >>> device.run_commands('show hostname')
    [{u'hostname': u'new-hostname', u'fqdn': u'new-hostname'}]
    >>> device.run_commands('show banner login')
    [{u'loginBanner': u'This is a new banner\nwith different lines!!!\n'}]
    >>>