### PR TITLE
Handle dot and hyphen in mlag domain-id string

### DIFF
--- a/pyeapi/api/mlag.py
+++ b/pyeapi/api/mlag.py
@@ -116,7 +116,7 @@ class Mlag(Entity):
             dict: A dict object that is intended to be merged into the
                 resource dict
         """
-        match = re.search(r'domain-id ([\w\.\-]+)', config)
+        match = re.search(r'domain-id (.+)', config)
         value = match.group(1) if match else None
         return dict(domain_id=value)
 

--- a/pyeapi/api/mlag.py
+++ b/pyeapi/api/mlag.py
@@ -116,7 +116,7 @@ class Mlag(Entity):
             dict: A dict object that is intended to be merged into the
                 resource dict
         """
-        match = re.search(r'domain-id (.+)', config)
+        match = re.search(r'domain-id (.+)$', config)
         value = match.group(1) if match else None
         return dict(domain_id=value)
 

--- a/pyeapi/api/mlag.py
+++ b/pyeapi/api/mlag.py
@@ -116,7 +116,7 @@ class Mlag(Entity):
             dict: A dict object that is intended to be merged into the
                 resource dict
         """
-        match = re.search(r'domain-id (\w+)', config)
+        match = re.search(r'domain-id ([\w\.\-]+)', config)
         value = match.group(1) if match else None
         return dict(domain_id=value)
 

--- a/test/system/test_api_mlag.py
+++ b/test/system/test_api_mlag.py
@@ -55,9 +55,10 @@ class TestApiMlag(DutSystemTest):
             dut.config('default mlag configuration')
             api = dut.api('mlag')
             self.assertIn('no domain-id', api.get_block('mlag configuration'))
-            result = dut.api('mlag').set_domain_id('test.dom-id')
-            self.assertTrue(result)
-            self.assertIn('domain-id test', api.get_block('mlag configuration'))
+            for domid in ['test_domain_id', 'test.dom-id', 'test domain id']:
+                result = dut.api('mlag').set_domain_id(domid)
+                self.assertTrue(result)
+                self.assertIn('domain-id %s' % domid, api.get_block('mlag configuration'))
 
     def test_set_domain_id_with_no_value(self):
         for dut in self.duts:

--- a/test/system/test_api_mlag.py
+++ b/test/system/test_api_mlag.py
@@ -55,7 +55,7 @@ class TestApiMlag(DutSystemTest):
             dut.config('default mlag configuration')
             api = dut.api('mlag')
             self.assertIn('no domain-id', api.get_block('mlag configuration'))
-            result = dut.api('mlag').set_domain_id('test')
+            result = dut.api('mlag').set_domain_id('test.dom-id')
             self.assertTrue(result)
             self.assertIn('domain-id test', api.get_block('mlag configuration'))
 

--- a/test/unit/test_api_mlag.py
+++ b/test/unit/test_api_mlag.py
@@ -66,8 +66,8 @@ class TestApiMlag(EapiConfigUnitTest):
         for state in ['config', 'negate', 'default']:
             cmds = ['mlag configuration']
             if state == 'config':
-                cmds.append('domain-id test.dom-id')
-                func = function('set_domain_id', 'test.dom-id')
+                cmds.append('domain-id test.dom-id string')
+                func = function('set_domain_id', 'test.dom-id string')
             elif state == 'negate':
                 cmds.append('no domain-id')
                 func = function('set_domain_id', value='test', disable=True)

--- a/test/unit/test_api_mlag.py
+++ b/test/unit/test_api_mlag.py
@@ -66,8 +66,8 @@ class TestApiMlag(EapiConfigUnitTest):
         for state in ['config', 'negate', 'default']:
             cmds = ['mlag configuration']
             if state == 'config':
-                cmds.append('domain-id test')
-                func = function('set_domain_id', 'test')
+                cmds.append('domain-id test.dom-id')
+                func = function('set_domain_id', 'test.dom-id')
             elif state == 'negate':
                 cmds.append('no domain-id')
                 func = function('set_domain_id', value='test', disable=True)


### PR DESCRIPTION
fixes #91
Addresses arista-eosplus/ansible-eos#90

Release Note:
Include handling any character in domain-id string, including dot, hyphen, and space
