### PR TITLE
Replace syslog calls with logging library

### DIFF
--- a/pyeapi/client.py
+++ b/pyeapi/client.py
@@ -105,30 +105,11 @@ except ImportError:
     from ConfigParser import SafeConfigParser
     from ConfigParser import Error as SafeConfigParserError
 
-from pyeapi.utils import load_module, make_iterable
+from pyeapi.utils import load_module, make_iterable, debug
 
 from pyeapi.eapilib import HttpEapiConnection, HttpsEapiConnection
 from pyeapi.eapilib import SocketEapiConnection, HttpLocalEapiConnection
 from pyeapi.eapilib import CommandError
-
-if sys.platform == "darwin":
-    # Mac OS syslog
-    address = '/var/run/syslog'
-elif sys.platform == "win32":
-    # Windows write to localhost, port 514
-    # This is the default SysLogHandler address, but needs to be
-    # specified since we are using a variable.
-    address = ('localhost', 514)
-else:
-    # Most *nix syslog
-    address = '/var/log/syslog'
-
-LOGGER = logging.getLogger(__name__)
-LOGGER.setLevel(logging.DEBUG)
-handler = logging.handlers.SysLogHandler()
-formatter = logging.Formatter('pyeapi.%(module)s.%(funcName)s: %(message)s')
-handler.setFormatter(formatter)
-LOGGER.addHandler(handler)
 
 CONFIG_SEARCH_PATH = ['~/.eapi.conf', '/mnt/flash/eapi.conf']
 
@@ -218,7 +199,7 @@ class Config(SafeConfigParser):
             # Ignore file and syslog a message on SafeConfigParser errors
             msg = ("%s: parsing error in eapi conf file: %s" %
                    (type(exc).__name__, filename))
-            LOGGER.debug(msg)
+            debug(msg)
 
         self._add_default_connection()
 

--- a/pyeapi/client.py
+++ b/pyeapi/client.py
@@ -121,7 +121,7 @@ elif sys.platform == "win32":
     address = ('localhost', 514)
 else:
     # Most *nix syslog
-    address = '/dev/log'
+    address = '/var/log/syslog'
 
 LOGGER = logging.getLogger(__name__)
 LOGGER.setLevel(logging.DEBUG)

--- a/pyeapi/client.py
+++ b/pyeapi/client.py
@@ -91,6 +91,7 @@ contains the settings for nodes used by the connect_to function.
 
 """
 import os
+import sys
 import logging
 import re
 
@@ -104,13 +105,30 @@ except ImportError:
     from ConfigParser import SafeConfigParser
     from ConfigParser import Error as SafeConfigParserError
 
-from pyeapi.utils import load_module, make_iterable, syslog_warning
+from pyeapi.utils import load_module, make_iterable
 
 from pyeapi.eapilib import HttpEapiConnection, HttpsEapiConnection
 from pyeapi.eapilib import SocketEapiConnection, HttpLocalEapiConnection
 from pyeapi.eapilib import CommandError
 
+if sys.platform == "darwin":
+    # Mac OS syslog
+    address = '/var/run/syslog'
+elif sys.platform == "win32":
+    # Windows write to localhost, port 514
+    # This is the default SysLogHandler address, but needs to be
+    # specified since we are using a variable.
+    address = ('localhost', 514)
+else:
+    # Most *nix syslog
+    address = '/dev/log'
+
 LOGGER = logging.getLogger(__name__)
+LOGGER.setLevel(logging.DEBUG)
+handler = logging.handlers.SysLogHandler(address=address)
+formatter = logging.Formatter('pyeapi.%(module)s.%(funcName)s: %(message)s')
+handler.setFormatter(formatter)
+LOGGER.addHandler(handler)
 
 CONFIG_SEARCH_PATH = ['~/.eapi.conf', '/mnt/flash/eapi.conf']
 
@@ -193,12 +211,14 @@ class Config(SafeConfigParser):
         Args:
             filename (str): The full path to the file to load
         """
+
         try:
             SafeConfigParser.read(self, filename)
         except SafeConfigParserError as exc:
             # Ignore file and syslog a message on SafeConfigParser errors
-            syslog_warning("%s: parsing error in eapi conf file: %s" %
-                           (type(exc).__name__, filename))
+            msg = ("%s: parsing error in eapi conf file: %s" %
+                   (type(exc).__name__, filename))
+            LOGGER.debug(msg)
 
         self._add_default_connection()
 

--- a/pyeapi/client.py
+++ b/pyeapi/client.py
@@ -125,7 +125,7 @@ else:
 
 LOGGER = logging.getLogger(__name__)
 LOGGER.setLevel(logging.DEBUG)
-handler = logging.handlers.SysLogHandler(address=address)
+handler = logging.handlers.SysLogHandler()
 formatter = logging.Formatter('pyeapi.%(module)s.%(funcName)s: %(message)s')
 handler.setFormatter(formatter)
 LOGGER.addHandler(handler)

--- a/pyeapi/eapilib.py
+++ b/pyeapi/eapilib.py
@@ -389,7 +389,7 @@ class EapiConnection(object):
                 # For Python 3.x - decode bytes into string
                 response_content = response_content.decode()
             decoded = json.loads(response_content)
-            debug('eapi_response: %s' % decoded)
+            _LOGGER.debug('eapi_response: %s' % decoded)
 
             if 'error' in decoded:
                 (code, msg, err, out) = self._parse_error_message(decoded)

--- a/pyeapi/utils.py
+++ b/pyeapi/utils.py
@@ -32,9 +32,9 @@
 import os
 import sys
 import imp
+import inspect
 import logging
 import logging.handlers
-import syslog
 import collections
 
 from itertools import tee
@@ -47,10 +47,20 @@ except ImportError:
     from itertools import izip_longest as zip_longest
 
 _LOGGER = logging.getLogger(__name__)
+_LOGGER.setLevel(logging.DEBUG)
 
-_syslog_handler = logging.handlers.SysLogHandler()
+# Create a handler to log messages to syslog
+if sys.platform == "darwin":
+    _syslog_handler = logging.handlers.SysLogHandler(address='/var/run/syslog')
+else:
+    _syslog_handler = logging.handlers.SysLogHandler()
 _LOGGER.addHandler(_syslog_handler)
-_LOGGER.setLevel(logging.INFO)
+
+# Create a handler to log messages to stderr
+_stderr_formatter = logging.Formatter('\n\n******** LOG NOTE ********\n%(message)s\n')
+_stderr_handler = logging.StreamHandler()
+_stderr_handler.setFormatter(_stderr_formatter)
+_LOGGER.addHandler(_stderr_handler)
 
 def import_module(name):
     """ Imports a module into the current runtime environment
@@ -140,15 +150,17 @@ def islocalconnection():
     return os.path.exists('/etc/Eos-release')
 
 def debug(text):
-    """Prints text to syslog when on a local connection
+    """Log a message to syslog and stderr
 
     Args:
-        text (str): The string object to print to syslog
+        text (str): The string object to print
 
     """
-
-    if islocalconnection():
-        _LOGGER.debug(text)
+    frame = inspect.currentframe().f_back
+    module = frame.f_globals['__name__']
+    func = frame.f_code.co_name
+    msg = "%s.%s: %s" % (module, func, text)
+    _LOGGER.debug(msg)
 
 def make_iterable(value):
     """Converts the supplied value to a list object

--- a/pyeapi/utils.py
+++ b/pyeapi/utils.py
@@ -150,17 +150,6 @@ def debug(text):
     if islocalconnection():
         _LOGGER.debug(text)
 
-def syslog_warning(text):
-    """Print text to syslog at warning level
-
-    Args:
-        text (str): The string object to print to syslog
-
-    """
-
-    syslog.openlog("pyeapi")
-    syslog.syslog(syslog.LOG_WARNING, text)
-
 def make_iterable(value):
     """Converts the supplied value to a list object
 

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -76,4 +76,4 @@ class TestUtils(unittest.TestCase):
     def test_debug(self, mock_logger):
         pyeapi.utils.islocalconnection = Mock(return_value=True)
         pyeapi.utils.debug('test')
-        mock_logger.debug.assert_called_with('test')
+        mock_logger.debug.assert_called_with('test_utils.test_debug: test')


### PR DESCRIPTION
fixes #93 

Release Notes:
Use logging instead of syslog for better cross-platform compatibility
