### PR TITLE
Update vxlan api

### DIFF
--- a/pyeapi/api/interfaces.py
+++ b/pyeapi/api/interfaces.py
@@ -756,7 +756,7 @@ class VxlanInterface(BaseInterface):
         return dict(source_interface=value)
 
     def _parse_multicast_group(self, config):
-        match = re.search(r'vxlan multicast-group ([\d]{3}\.[\d]+.[\d]+.[\d]+)', 
+        match = re.search(r'vxlan multicast-group ([\d]{3}\.[\d]+\.[\d]+\.[\d]+)', 
                           config)
         value = match.group(1) if match else self.DEFAULT_MCAST_GRP
         return dict(multicast_group=value)

--- a/pyeapi/api/interfaces.py
+++ b/pyeapi/api/interfaces.py
@@ -710,6 +710,8 @@ class VxlanInterface(BaseInterface):
             * udp_port (int): The vxlan udp-port value
             * vlans (dict): The vlan to vni mappings
             * flood_list (list): The list of global VTEP flood list
+            * multicast_decap (bool): If the mutlicast decap 
+                                      feature is configured
 
         Args:
             name (str): The interface identifier to retrieve from the
@@ -732,6 +734,7 @@ class VxlanInterface(BaseInterface):
         response.update(self._parse_udp_port(config))
         response.update(self._parse_vlans(config))
         response.update(self._parse_flood_list(config))
+        response.update(self._parse_multicast_decap(config))
 
         return response
 
@@ -753,9 +756,14 @@ class VxlanInterface(BaseInterface):
         return dict(source_interface=value)
 
     def _parse_multicast_group(self, config):
-        match = re.search(r'vxlan multicast-group ([^\s]+)', config)
+        match = re.search(r'vxlan multicast-group ([\d]{3}\.[\d]+.[\d]+.[\d]+)', 
+                          config)
         value = match.group(1) if match else self.DEFAULT_MCAST_GRP
         return dict(multicast_group=value)
+   
+    def _parse_multicast_decap(self, config):
+        value = 'vxlan mutlicast-group decap' in config
+        return dict(multicast_decap=bool(value))
 
     def _parse_udp_port(self, config):
         match = re.search(r'vxlan udp-port (\d+)', config)
@@ -830,6 +838,31 @@ class VxlanInterface(BaseInterface):
         cmds = self.command_builder(string, value=value, default=default,
                                     disable=disable)
         return self.configure_interface(name, cmds)
+
+    def set_multicast_decap(self, name, default=False,
+                           disable=False):
+        """Configures the Vxlan multicast-group decap feature 
+
+        EosVersion:
+            4.15.0M
+
+        Args:
+            name(str): The interface identifier to configure, defaults to
+                Vxlan1
+           default(bool): Configures the mulitcast-group decap value to default
+           disable(bool): Negates the multicast-group decap value
+
+        Returns:
+            True if the operation succeeds otherwise False
+        """
+        string = 'vxlan multicast-group decap'
+        if(default or disable):
+            cmds = self.command_builder(string, value=None, default=default,
+                                       disable=disable)
+        else:
+            cmds = [string] 
+        return self.configure_interface(name, cmds)
+
 
     def set_udp_port(self, name, value=None, default=False, disable=False):
         """Configures vxlan udp-port value

--- a/test/fixtures/running_config.vxlan
+++ b/test/fixtures/running_config.vxlan
@@ -46,4 +46,5 @@ interface Vxlan1
    no vxlan vlan flood vtep
    no vxlan learn-restrict vtep
    no vxlan vlan learn-restrict vtep
+   no vxlan multicast-group decap
 !

--- a/test/fixtures/vxlan.json
+++ b/test/fixtures/vxlan.json
@@ -9,6 +9,7 @@
             "vlanToVtepList": {},
             "mtu": 0,
             "hardware": "vxlan",
+            "mcastGrpDecap": "",
             "replicationMode": "multicast",
             "bandwidth": 0,
             "floodMcastGrp": "239.10.10.10",

--- a/test/system/test_api_interfaces.py
+++ b/test/system/test_api_interfaces.py
@@ -341,6 +341,8 @@ class TestApiVxlanInterface(DutSystemTest):
             self.assertEqual(result['description'], None)
             self.assertEqual(result['source_interface'], '')
             self.assertEqual(result['multicast_group'], '')
+            self.assertEqual(result['multicast_decap'], False)
+
 
     def get_config(self, dut):
         cmd = 'show running-config all interfaces Vxlan1'
@@ -404,6 +406,16 @@ class TestApiVxlanInterface(DutSystemTest):
             instance = api.set_multicast_group('Vxlan1', disable=True)
             self.assertTrue(instance)
             self.contains('no vxlan multicast-group', dut)
+
+    '''commenting this one out as it will only parse on a  trident based DUT
+    def test_set_multicast_decap(self):
+        for dut in self.duts:
+            dut.config(['no interface Vxlan1', 'interface Vxlan1'])
+            api = dut.api('interfaces')
+            instance = api.set_multicast_decap('Vxlan1')
+            self.assertTrue(instance)
+            self.contains('vxlan multicast-group decap', dut)
+    '''
 
     def test_set_udp_port(self):
         for dut in self.duts:

--- a/test/system/test_client.py
+++ b/test/system/test_client.py
@@ -71,9 +71,8 @@ class TestClient(unittest.TestCase):
 
     def test_no_enable_single_command_no_auth(self):
         for dut in self.duts:
-            dut.run_commands('disable')
             with self.assertRaises(pyeapi.eapilib.CommandError):
-                dut.run_commands('show running-config', 'json', send_enable=False)
+                dut.run_commands(['disable', 'show running-config'], 'json', send_enable=False)
 
     def test_enable_multiple_commands(self):
         for dut in self.duts:
@@ -187,7 +186,7 @@ class TestNode(unittest.TestCase):
         # Send a continuous command that requires a break
         cases.append(('watch 10 show int e1 count rates', rfmt
                       % (1000, 'could not run command',
-                         'init error \(cbreak\(\) returned ERR\)')))
+                         'init error.*')))
         # Send a command that has insufficient priv
         cases.append(('show running-config', rfmt
                       % (1002, 'invalid command',

--- a/test/unit/test_api_interfaces.py
+++ b/test/unit/test_api_interfaces.py
@@ -407,8 +407,6 @@ class TestApiVxlanInterface(EapiConfigUnitTest):
         func = function('set_multicast_decap', 'Vxlan1', default=True)
         self.eapi_positive_config_test(func, cmds)
 
-
-
     def test_set_udp_port_with_value(self):
         cmds = ['interface Vxlan1', 'vxlan udp-port 1024']
         func = function('set_udp_port', 'Vxlan1', '1024')

--- a/test/unit/test_api_interfaces.py
+++ b/test/unit/test_api_interfaces.py
@@ -357,7 +357,8 @@ class TestApiVxlanInterface(EapiConfigUnitTest):
 
     def test_get(self):
         keys = ['name', 'type', 'description', 'shutdown', 'source_interface',
-                'multicast_group', 'udp_port', 'vlans', 'flood_list']
+                'multicast_group', 'udp_port', 'vlans', 'flood_list',
+                'multicast_decap']
         result = self.instance.get('Vxlan1')
         self.assertEqual(sorted(keys), sorted(result.keys()))
 
@@ -390,6 +391,23 @@ class TestApiVxlanInterface(EapiConfigUnitTest):
         cmds = ['interface Vxlan1', 'default vxlan multicast-group']
         func = function('set_multicast_group', 'Vxlan1', default=True)
         self.eapi_positive_config_test(func, cmds)
+
+    def test_set_multicast_decap(self):
+        cmds = ['interface Vxlan1', 'vxlan multicast-group decap']
+        func = function('set_multicast_decap', 'Vxlan1')
+        self.eapi_positive_config_test(func, cmds)
+
+    def test_set_multicast_decap_with_no_value(self):
+        cmds = ['interface Vxlan1', 'no vxlan multicast-group decap']
+        func = function('set_multicast_decap', 'Vxlan1', disable=True)
+        self.eapi_positive_config_test(func, cmds)
+
+    def test_set_multicast_decap_with_default(self):
+        cmds = ['interface Vxlan1', 'default vxlan multicast-group decap']
+        func = function('set_multicast_decap', 'Vxlan1', default=True)
+        self.eapi_positive_config_test(func, cmds)
+
+
 
     def test_set_udp_port_with_value(self):
         cmds = ['interface Vxlan1', 'vxlan udp-port 1024']


### PR DESCRIPTION
fixes #105 

This is a bit of a strange corner case where when testing the ```vxlan mutlicast-group decap``` you can only run the system test on a Trident based system as this is the only system that supports this command.  However the default configuration in ```show run all int vxlan <x>``` has ```no vxlan multicast-group decap``` for all platforms and vEOS.  So I commented out the system test until we can have a mechanism to determine what platform we are running tests against.


Systest results:

$ make systest
Cleaning up distutils stuff
rm -rf build
rm -rf dist
rm -rf MANIFEST
rm -rf *.egg-info
Cleaning up byte compiled python stuff
find . -type f -regex ".*\.py[co]$" -delete
Cleaning up doc builds
rm -rf docs/_build
rm -rf docs/api_modules
rm -rf docs/client_modules
coverage run -m unittest discover test/system -v
test_add_entry (test_api_acl.TestApiStandardAcls) ... ok
test_create (test_api_acl.TestApiStandardAcls) ... ok
test_default (test_api_acl.TestApiStandardAcls) ... ok
test_delete (test_api_acl.TestApiStandardAcls) ... ok
test_get (test_api_acl.TestApiStandardAcls) ... ok
test_get_none (test_api_acl.TestApiStandardAcls) ... ok
test_getall (test_api_acl.TestApiStandardAcls) ... ok
test_remove_entry (test_api_acl.TestApiStandardAcls) ... ok
test_update_entry (test_api_acl.TestApiStandardAcls) ... ok
test_update_entry_existing (test_api_acl.TestApiStandardAcls) ... ok
test_add_vtep (test_api_interfaces.TestApiVxlanInterface) ... ok
test_add_vtep_to_vlan (test_api_interfaces.TestApiVxlanInterface) ... ok
test_get (test_api_interfaces.TestApiVxlanInterface) ... ok
test_remove_vlan (test_api_interfaces.TestApiVxlanInterface) ... ok
test_remove_vtep (test_api_interfaces.TestApiVxlanInterface) ... ok
test_remove_vtep_from_vlan (test_api_interfaces.TestApiVxlanInterface) ... ok
test_set_multicast_group (test_api_interfaces.TestApiVxlanInterface) ... ok
test_set_multicast_group_default (test_api_interfaces.TestApiVxlanInterface) ... ok
test_set_multicast_group_negate (test_api_interfaces.TestApiVxlanInterface) ... ok
test_set_source_interface (test_api_interfaces.TestApiVxlanInterface) ... ok
test_set_source_interface_default (test_api_interfaces.TestApiVxlanInterface) ... ok
test_set_source_interface_negate (test_api_interfaces.TestApiVxlanInterface) ... ok
test_set_udp_port (test_api_interfaces.TestApiVxlanInterface) ... ok
test_set_udp_port_default (test_api_interfaces.TestApiVxlanInterface) ... ok
test_set_udp_port_negate (test_api_interfaces.TestApiVxlanInterface) ... ok
test_update_vlan (test_api_interfaces.TestApiVxlanInterface) ... ok
test_get (test_api_interfaces.TestPortchannelInterface) ... ok
test_get_lacp_mode_with_default (test_api_interfaces.TestPortchannelInterface) ... ok
test_get_members_default (test_api_interfaces.TestPortchannelInterface) ... ok
test_get_members_one_member (test_api_interfaces.TestPortchannelInterface) ... ok
test_get_members_two_members (test_api_interfaces.TestPortchannelInterface) ... ok
test_minimum_links_invalid_value (test_api_interfaces.TestPortchannelInterface) ... ok
test_minimum_links_valid (test_api_interfaces.TestPortchannelInterface) ... ok
test_set_lacp_mode (test_api_interfaces.TestPortchannelInterface) ... ok
test_set_lacp_mode_invalid_value (test_api_interfaces.TestPortchannelInterface) ... ok
test_set_members (test_api_interfaces.TestPortchannelInterface) ... ok
test_set_members_with_mode (test_api_interfaces.TestPortchannelInterface) ... ok
test_create_and_return_true (test_api_interfaces.TestResourceInterfaces) ... ok
test_create_ethernet_raises_not_implemented_error (test_api_interfaces.TestResourceInterfaces) ... ok
test_default (test_api_interfaces.TestResourceInterfaces) ... ok
test_delete_and_return_true (test_api_interfaces.TestResourceInterfaces) ... ok
test_delete_ethernet_raises_not_implemented_error (test_api_interfaces.TestResourceInterfaces) ... ok
test_get (test_api_interfaces.TestResourceInterfaces) ... ok
test_getall (test_api_interfaces.TestResourceInterfaces) ... ok
test_set_description (test_api_interfaces.TestResourceInterfaces) ... ok
test_set_description_default (test_api_interfaces.TestResourceInterfaces) ... ok
test_set_description_negate (test_api_interfaces.TestResourceInterfaces) ... ok
test_set_sflow_default (test_api_interfaces.TestResourceInterfaces) ... ok
test_set_sflow_disable (test_api_interfaces.TestResourceInterfaces) ... ok
test_set_sflow_enable (test_api_interfaces.TestResourceInterfaces) ... ok
test_create_and_return_true (test_api_ipinterfaces.TestResourceIpinterfaces) ... ok
test_delete_and_return_true (test_api_ipinterfaces.TestResourceIpinterfaces) ... ok
test_get (test_api_ipinterfaces.TestResourceIpinterfaces) ... ok
test_get_interface_wo_ip_adddress (test_api_ipinterfaces.TestResourceIpinterfaces) ... ok
test_getall (test_api_ipinterfaces.TestResourceIpinterfaces) ... ok
test_set_address (test_api_ipinterfaces.TestResourceIpinterfaces) ... ok
test_set_mtu (test_api_ipinterfaces.TestResourceIpinterfaces) ... ok
test_set_mtu_value_as_string (test_api_ipinterfaces.TestResourceIpinterfaces) ... ok
test_get (test_api_mlag.TestApiMlag) ... ok
test_set_domain_id_with_default (test_api_mlag.TestApiMlag) ... ok
test_set_domain_id_with_no_value (test_api_mlag.TestApiMlag) ... ok
test_set_domain_id_with_value (test_api_mlag.TestApiMlag) ... ok
test_set_local_interface_with_default (test_api_mlag.TestApiMlag) ... ok
test_set_local_interface_with_no_value (test_api_mlag.TestApiMlag) ... ok
test_set_local_interface_with_value (test_api_mlag.TestApiMlag) ... ok
test_set_mlag_id_with_default (test_api_mlag.TestApiMlag) ... ok
test_set_mlag_id_with_no_value (test_api_mlag.TestApiMlag) ... ok
test_set_mlag_id_with_value (test_api_mlag.TestApiMlag) ... ok
test_set_peer_address_with_default (test_api_mlag.TestApiMlag) ... ok
test_set_peer_address_with_no_value (test_api_mlag.TestApiMlag) ... ok
test_set_peer_address_with_value (test_api_mlag.TestApiMlag) ... ok
test_set_peer_link_with_default (test_api_mlag.TestApiMlag) ... ok
test_set_peer_link_with_no_value (test_api_mlag.TestApiMlag) ... ok
test_set_peer_link_with_value (test_api_mlag.TestApiMlag) ... ok
test_set_peer_link_with_value_portchannel (test_api_mlag.TestApiMlag) ... ok
test_set_shutdown_with_default (test_api_mlag.TestApiMlag) ... ok
test_set_shutdown_with_false (test_api_mlag.TestApiMlag) ... ok
test_set_shutdown_with_no_value (test_api_mlag.TestApiMlag) ... ok
test_set_shutdown_with_true (test_api_mlag.TestApiMlag) ... ok
test_add_server_invalid (test_api_ntp.TestApiNtp) ... ok
test_add_server_multiple (test_api_ntp.TestApiNtp) ... ok
test_add_server_prefer (test_api_ntp.TestApiNtp) ... ok
test_add_server_single (test_api_ntp.TestApiNtp) ... ok
test_create (test_api_ntp.TestApiNtp) ... ok
test_default (test_api_ntp.TestApiNtp) ... ok
test_delete (test_api_ntp.TestApiNtp) ... ok
test_get (test_api_ntp.TestApiNtp) ... ok
test_remove_all_servers (test_api_ntp.TestApiNtp) ... ok
test_remove_server (test_api_ntp.TestApiNtp) ... ok
test_set_source_interface (test_api_ntp.TestApiNtp) ... ok
test_add_network (test_api_ospf.TestApiOspf) ... ok
test_add_redistribution (test_api_ospf.TestApiOspf) ... ok
test_configure_ospf (test_api_ospf.TestApiOspf) ... ok
test_create_invalid_id (test_api_ospf.TestApiOspf) ... ok
test_create_valid_id (test_api_ospf.TestApiOspf) ... ok
test_delete (test_api_ospf.TestApiOspf) ... ok
test_get (test_api_ospf.TestApiOspf) ... ok
test_no_shutown (test_api_ospf.TestApiOspf) ... ok
test_remove_network (test_api_ospf.TestApiOspf) ... ok
test_remove_redistribution (test_api_ospf.TestApiOspf) ... ok
test_set_router_id (test_api_ospf.TestApiOspf) ... ok
test_shutdown (test_api_ospf.TestApiOspf) ... ok
test_create (test_api_routemaps.TestApiRoutemaps) ... ok
test_create_with_hyphen (test_api_routemaps.TestApiRoutemaps) ... ok
test_create_with_underscore (test_api_routemaps.TestApiRoutemaps) ... ok
test_default (test_api_routemaps.TestApiRoutemaps) ... ok
test_default_continue (test_api_routemaps.TestApiRoutemaps) ... ok
test_delete (test_api_routemaps.TestApiRoutemaps) ... ok
test_get (test_api_routemaps.TestApiRoutemaps) ... ok
test_get_none (test_api_routemaps.TestApiRoutemaps) ... ok
test_getall (test_api_routemaps.TestApiRoutemaps) ... ok
test_negate_continue (test_api_routemaps.TestApiRoutemaps) ... ok
test_remove_match_statement (test_api_routemaps.TestApiRoutemaps) ... ok
test_remove_set_statement (test_api_routemaps.TestApiRoutemaps) ... ok
test_set_continue (test_api_routemaps.TestApiRoutemaps) ... ok
test_set_description (test_api_routemaps.TestApiRoutemaps) ... ok
test_set_match_statements (test_api_routemaps.TestApiRoutemaps) ... ok
test_set_set_statements (test_api_routemaps.TestApiRoutemaps) ... ok
test_update_continue (test_api_routemaps.TestApiRoutemaps) ... ok
test_update_match_statement (test_api_routemaps.TestApiRoutemaps) ... ok
test_update_set_statement (test_api_routemaps.TestApiRoutemaps) ... ok
test_create (test_api_staticroute.TestApiStaticroute) ... ok
test_default (test_api_staticroute.TestApiStaticroute) ... ok
test_delete (test_api_staticroute.TestApiStaticroute) ... ok
test_get (test_api_staticroute.TestApiStaticroute) ... ok
test_getall (test_api_staticroute.TestApiStaticroute) ... ok
test_set_route_name (test_api_staticroute.TestApiStaticroute) ... ok
test_set_tag (test_api_staticroute.TestApiStaticroute) ... ok
test_get (test_api_stp.TestApiStpInterfaces) ... ok
test_getall (test_api_stp.TestApiStpInterfaces) ... ok
test_set_bpdugard_to_default (test_api_stp.TestApiStpInterfaces) ... ok
test_set_bpdugard_to_false (test_api_stp.TestApiStpInterfaces) ... ok
test_set_bpdugard_to_no (test_api_stp.TestApiStpInterfaces) ... ok
test_set_bpduguard_to_true (test_api_stp.TestApiStpInterfaces) ... ok
test_set_portfast_to_default (test_api_stp.TestApiStpInterfaces) ... ok
test_set_portfast_to_edge (test_api_stp.TestApiStpInterfaces) ... ok
test_set_portfast_to_false (test_api_stp.TestApiStpInterfaces) ... ok
test_set_portfast_to_network (test_api_stp.TestApiStpInterfaces) ... ok
test_set_portfast_to_no (test_api_stp.TestApiStpInterfaces) ... ok
test_set_portfast_to_true (test_api_stp.TestApiStpInterfaces) ... ok
test_create_and_return_true (test_api_switchports.TestApiSwitchports) ... ok
test_delete_and_return_true (test_api_switchports.TestApiSwitchports) ... ok
test_get (test_api_switchports.TestApiSwitchports) ... ok
test_get_returns_none (test_api_switchports.TestApiSwitchports) ... ok
test_getall (test_api_switchports.TestApiSwitchports) ... ok
test_set_access_vlan_to_value (test_api_switchports.TestApiSwitchports) ... ok
test_set_trunk_allowed_vlans (test_api_switchports.TestApiSwitchports) ... ok
test_set_trunk_native_vlan (test_api_switchports.TestApiSwitchports) ... ok
test_get (test_api_system.TestApiSystem) ... ok
test_get_banner_with_EOF (test_api_system.TestApiSystem) ... ok
test_get_check_banners (test_api_system.TestApiSystem) ... ok
test_get_check_hostname (test_api_system.TestApiSystem) ... ok
test_get_with_period (test_api_system.TestApiSystem) ... ok
test_set_banner_login (test_api_system.TestApiSystem) ... ok
test_set_banner_login_default (test_api_system.TestApiSystem) ... ok
test_set_banner_login_negate (test_api_system.TestApiSystem) ... ok
test_set_banner_motd (test_api_system.TestApiSystem) ... ok
test_set_banner_motd_default (test_api_system.TestApiSystem) ... ok
test_set_banner_motd_donkey (test_api_system.TestApiSystem) ... ok
test_set_hostname_default_over_value (test_api_system.TestApiSystem) ... ok
test_set_hostname_with_default (test_api_system.TestApiSystem) ... ok
test_set_hostname_with_no_value (test_api_system.TestApiSystem) ... ok
test_set_hostname_with_period (test_api_system.TestApiSystem) ... ok
test_set_hostname_with_value (test_api_system.TestApiSystem) ... ok
test_set_iprouting_to_default (test_api_system.TestApiSystem) ... ok
test_set_iprouting_to_false (test_api_system.TestApiSystem) ... ok
test_set_iprouting_to_no (test_api_system.TestApiSystem) ... ok
test_set_iprouting_to_true (test_api_system.TestApiSystem) ... ok
test_create (test_api_users.TestApiUsers) ... ok
test_default (test_api_users.TestApiUsers) ... ok
test_delete (test_api_users.TestApiUsers) ... ok
test_get (test_api_users.TestApiUsers) ... ok
test_getall (test_api_users.TestApiUsers) ... ok
test_set_privilege_with_no_value (test_api_users.TestApiUsers) ... ok
test_set_privilege_with_value (test_api_users.TestApiUsers) ... ok
test_set_role_with_no_value (test_api_users.TestApiUsers) ... ok
test_set_role_with_value (test_api_users.TestApiUsers) ... ok
test_set_sshkey_with_None (test_api_users.TestApiUsers) ... ok
test_set_sshkey_with_empty_string (test_api_users.TestApiUsers) ... ok
test_set_sshkey_with_no_value (test_api_users.TestApiUsers) ... ok
test_set_sshkey_with_value (test_api_users.TestApiUsers) ... ok
test_basic_get (test_api_varp.TestApiVarp) ... ok
test_change_mac_address (test_api_varp.TestApiVarp) ... ok
test_get_none (test_api_varp.TestApiVarp) ... ok
test_get_with_value (test_api_varp.TestApiVarp) ... ok
test_remove_mac_address (test_api_varp.TestApiVarp) ... ok
test_set_mac_address_with_bad_value (test_api_varp.TestApiVarp) ... ok
test_set_mac_address_with_value (test_api_varp.TestApiVarp) ... ok
test_default_virtual_addrs (test_api_varp.TestApiVarpInterfaces) ... ok
test_empty_list_virtual_addrs (test_api_varp.TestApiVarpInterfaces) ... ok
test_negate_virtual_addrs (test_api_varp.TestApiVarpInterfaces) ... ok
test_negate_virtual_addrs_with_disable (test_api_varp.TestApiVarpInterfaces) ... ok
test_no_attr_virtual_addrs (test_api_varp.TestApiVarpInterfaces) ... ok
test_set_virtual_addr_with_values_clean (test_api_varp.TestApiVarpInterfaces) ... ok
test_set_virtual_addr_with_values_dirty (test_api_varp.TestApiVarpInterfaces) ... ok
test_add_trunk_group (test_api_vlans.TestApiVlans) ... ok
test_create_and_return_false (test_api_vlans.TestApiVlans) ... ok
test_create_and_return_true (test_api_vlans.TestApiVlans) ... ok
test_default (test_api_vlans.TestApiVlans) ... ok
test_delete_and_return_false (test_api_vlans.TestApiVlans) ... ok
test_delete_and_return_true (test_api_vlans.TestApiVlans) ... ok
test_get (test_api_vlans.TestApiVlans) ... ok
test_getall (test_api_vlans.TestApiVlans) ... ok
test_remove_trunk_group (test_api_vlans.TestApiVlans) ... ok
test_set_name (test_api_vlans.TestApiVlans) ... ok
test_set_state_active (test_api_vlans.TestApiVlans) ... ok
test_set_state_suspend (test_api_vlans.TestApiVlans) ... ok
test_set_trunk_groups (test_api_vlans.TestApiVlans) ... ok
test_set_trunk_groups_default (test_api_vlans.TestApiVlans) ... ok
test_set_trunk_groups_disable (test_api_vlans.TestApiVlans) ... ok
test_create (test_api_vrrp.TestApiVrrp) ... ok
test_default (test_api_vrrp.TestApiVrrp) ... ok
test_delete (test_api_vrrp.TestApiVrrp) ... ok
test_get (test_api_vrrp.TestApiVrrp) ... ok
test_getall (test_api_vrrp.TestApiVrrp) ... ok
test_set_bfd_ip (test_api_vrrp.TestApiVrrp) ... ok
test_set_delay_reload (test_api_vrrp.TestApiVrrp) ... ok
test_set_description (test_api_vrrp.TestApiVrrp) ... ok
test_set_enable (test_api_vrrp.TestApiVrrp) ... ok
test_set_ip_version (test_api_vrrp.TestApiVrrp) ... ok
test_set_mac_addr_adv_interval (test_api_vrrp.TestApiVrrp) ... ok
test_set_preempt (test_api_vrrp.TestApiVrrp) ... ok
test_set_preempt_delay_min (test_api_vrrp.TestApiVrrp) ... ok
test_set_preempt_delay_reload (test_api_vrrp.TestApiVrrp) ... ok
test_set_primary_ip (test_api_vrrp.TestApiVrrp) ... ok
test_set_priority (test_api_vrrp.TestApiVrrp) ... ok
test_set_secondary_ips (test_api_vrrp.TestApiVrrp) ... ok
test_set_timers_advertise (test_api_vrrp.TestApiVrrp) ... ok
test_set_tracks (test_api_vrrp.TestApiVrrp) ... ok
test_update_with_create (test_api_vrrp.TestApiVrrp) ... ok
test_config_multiple_commands (test_client.TestClient) ... ok
test_config_single_command (test_client.TestClient) ... ok
test_config_single_multiline_command (test_client.TestClient) ... ok
test_enable_multiple_commands (test_client.TestClient) ... ok
test_enable_single_command (test_client.TestClient) ... ok
test_get_block (test_client.TestClient) ... ok
test_get_block_none (test_client.TestClient) ... ok
test_multiple_requests (test_client.TestClient) ... ok
test_no_enable_single_command (test_client.TestClient) ... ok
test_no_enable_single_command_no_auth (test_client.TestClient) ... ok
test_exception_trace (test_client.TestNode) ... ok

----------------------------------------------------------------------
Ran 241 tests in 283.577s

OK
