### PR TITLE
Fix test case when random is a valid VLAN

### DIFF
--- a/test/unit/test_api_vlans.py
+++ b/test/unit/test_api_vlans.py
@@ -49,7 +49,7 @@ class TestApiVlans(EapiConfigUnitTest):
         self.config = open(get_fixture('running_config.text')).read()
 
     def test_isvlan_with_string(self):
-        self.assertFalse(pyeapi.api.vlans.isvlan(random_string()))
+        self.assertFalse(pyeapi.api.vlans.isvlan('a' + random_string()))
 
     def test_isvlan_valid_value(self):
         self.assertTrue(pyeapi.api.vlans.isvlan('1234'))


### PR DESCRIPTION
A random string (like '214') can be a valid VLAN. Fix the test case such that the not-so-random string can never be a VLAN.