### PR TITLE
expose portchannel attributes :lacp fallback, lacp fallback timeout

### DIFF
--- a/pyeapi/api/interfaces.py
+++ b/pyeapi/api/interfaces.py
@@ -65,6 +65,8 @@ from pyeapi.utils import ProxyCall
 MIN_LINKS_RE = re.compile(r'(?<=\s{3}min-links\s)(?P<value>.+)$', re.M)
 
 DEFAULT_LACP_MODE = 'on'
+DEFAULT_LACP_FALLBACK = 'disabled'
+DEFAULT_LACP_FALLBACK_TIMEOUT = 90
 
 VALID_INTERFACES = frozenset([
     'Ethernet',
@@ -548,6 +550,8 @@ class PortchannelInterface(BaseInterface):
         response['members'] = self.get_members(name)
         response['lacp_mode'] = self.get_lacp_mode(name)
         response.update(self._parse_minimum_links(config))
+        response.update(self._parse_lacp_timeout(config))
+        response.update(self._parse_lacp_fallback(config))
         return response
 
     def _parse_minimum_links(self, config):
@@ -556,6 +560,20 @@ class PortchannelInterface(BaseInterface):
         if match:
             value = int(match.group(1))
         return dict(minimum_links=value)
+
+    def _parse_lacp_fallback(self, config):
+        value = DEFAULT_LACP_FALLBACK
+        match = re.search(r'lacp fallback (static|individual)', config)
+        if match:
+            value = match.group(1)
+        return dict(lacp_fallback=value)
+
+    def _parse_lacp_timeout(self, config):
+        value = DEFAULT_LACP_FALLBACK_TIMEOUT
+        match = re.search(r'lacp fallback timeout (\d+)', config)
+        if match:
+            value = int(match.group(1))
+        return dict(lacp_timeout=value)
 
     def get_lacp_mode(self, name):
         """Returns the LACP mode for the specified Port-Channel interface
@@ -687,6 +705,50 @@ class PortchannelInterface(BaseInterface):
         commands.append(self.command_builder('port-channel min-links',
                                              value=value, default=default,
                                              disable=disable))
+        return self.configure(commands)
+
+    def set_lacp_fallback(self, name, mode=None):
+        """Configures the Port-Channel lacp_fallback
+
+        Args:
+            name(str): The Port-Channel interface name
+
+            mode(str): The Port-Channel LACP fallback setting
+                Valid values are 'disabled', 'static', 'individual':
+
+                * static  - Fallback to static LAG mode
+                * individual - Fallback to individual ports
+                * disabled - Disable LACP fallback
+
+        Returns:
+            True if the operation succeeds otherwise False is returned
+        """
+        if mode not in ['disabled', 'static', 'individual']:
+            return False
+        disable = False
+        if mode == 'disabled':
+            disable = True
+        commands = ['interface %s' % name]
+        commands.append(self.command_builder('port-channel lacp fallback',
+                                             value=mode, disable=disable))
+        return self.configure(commands)
+
+    def set_lacp_timeout(self, name, value=None):
+        """Configures the Port-Channel LACP fallback timeout
+           The fallback timeout configures the period an interface in 
+           fallback mode remains in LACP mode without receiving a PDU.
+
+        Args:
+            name(str): The Port-Channel interface name
+
+            value(int): port-channel lacp fallback timeout in seconds
+
+        Returns:
+            True if the operation succeeds otherwise False is returned
+        """
+        commands = ['interface %s' % name]
+        commands.append(self.command_builder('port-channel lacp fallback timeout',
+                                             value=value))
         return self.configure(commands)
 
 
@@ -839,8 +901,7 @@ class VxlanInterface(BaseInterface):
                                     disable=disable)
         return self.configure_interface(name, cmds)
 
-    def set_multicast_decap(self, name, default=False,
-                           disable=False):
+    def set_multicast_decap(self, name, default=False, disable=False):
         """Configures the Vxlan multicast-group decap feature 
 
         EosVersion:
@@ -858,7 +919,7 @@ class VxlanInterface(BaseInterface):
         string = 'vxlan multicast-group decap'
         if(default or disable):
             cmds = self.command_builder(string, value=None, default=default,
-                                       disable=disable)
+                                        disable=disable)
         else:
             cmds = [string] 
         return self.configure_interface(name, cmds)

--- a/pyeapi/api/interfaces.py
+++ b/pyeapi/api/interfaces.py
@@ -735,7 +735,7 @@ class PortchannelInterface(BaseInterface):
 
     def set_lacp_timeout(self, name, value=None):
         """Configures the Port-Channel LACP fallback timeout
-           The fallback timeout configures the period an interface in 
+           The fallback timeout configures the period an interface in
            fallback mode remains in LACP mode without receiving a PDU.
 
         Args:
@@ -747,8 +747,8 @@ class PortchannelInterface(BaseInterface):
             True if the operation succeeds otherwise False is returned
         """
         commands = ['interface %s' % name]
-        commands.append(self.command_builder('port-channel lacp fallback timeout',
-                                             value=value))
+        string = 'port-channel lacp fallback timeout'
+        commands.append(self.command_builder(string, value=value))
         return self.configure(commands)
 
 
@@ -772,7 +772,7 @@ class VxlanInterface(BaseInterface):
             * udp_port (int): The vxlan udp-port value
             * vlans (dict): The vlan to vni mappings
             * flood_list (list): The list of global VTEP flood list
-            * multicast_decap (bool): If the mutlicast decap 
+            * multicast_decap (bool): If the mutlicast decap
                                       feature is configured
 
         Args:
@@ -818,11 +818,11 @@ class VxlanInterface(BaseInterface):
         return dict(source_interface=value)
 
     def _parse_multicast_group(self, config):
-        match = re.search(r'vxlan multicast-group ([\d]{3}\.[\d]+\.[\d]+\.[\d]+)', 
+        match = re.search(r'vxlan multicast-group ([\d]{3}\.[\d]+\.[\d]+\.[\d]+)',
                           config)
         value = match.group(1) if match else self.DEFAULT_MCAST_GRP
         return dict(multicast_group=value)
-   
+
     def _parse_multicast_decap(self, config):
         value = 'vxlan mutlicast-group decap' in config
         return dict(multicast_decap=bool(value))
@@ -902,7 +902,7 @@ class VxlanInterface(BaseInterface):
         return self.configure_interface(name, cmds)
 
     def set_multicast_decap(self, name, default=False, disable=False):
-        """Configures the Vxlan multicast-group decap feature 
+        """Configures the Vxlan multicast-group decap feature
 
         EosVersion:
             4.15.0M
@@ -921,7 +921,7 @@ class VxlanInterface(BaseInterface):
             cmds = self.command_builder(string, value=None, default=default,
                                         disable=disable)
         else:
-            cmds = [string] 
+            cmds = [string]
         return self.configure_interface(name, cmds)
 
 

--- a/pyeapi/api/interfaces.py
+++ b/pyeapi/api/interfaces.py
@@ -725,9 +725,7 @@ class PortchannelInterface(BaseInterface):
         """
         if mode not in ['disabled', 'static', 'individual']:
             return False
-        disable = False
-        if mode == 'disabled':
-            disable = True
+        disable = True if mode == 'disabled' else False
         commands = ['interface %s' % name]
         commands.append(self.command_builder('port-channel lacp fallback',
                                              value=mode, disable=disable))

--- a/pyeapi/client.py
+++ b/pyeapi/client.py
@@ -560,8 +560,8 @@ class Node(object):
         block_end = line_end + block_end
         return config[block_start:block_end]
 
-    def enable(self, commands, encoding='json', strict=False, 
-              send_enable=True):
+    def enable(self, commands, encoding='json', strict=False,
+               send_enable=True):
         """Sends the array of commands to the node in enable mode
 
         This method will send the commands to the node and evaluate

--- a/test/lib/testlib.py
+++ b/test/lib/testlib.py
@@ -54,6 +54,7 @@ def random_vlan():
 def random_int(minvalue, maxvalue):
     return random.randint(minvalue, maxvalue)
 
+
 from collections import namedtuple
 Function = namedtuple('Function', 'name args kwargs')
 

--- a/test/system/test_api_interfaces.py
+++ b/test/system/test_api_interfaces.py
@@ -492,5 +492,6 @@ class TestApiVxlanInterface(DutSystemTest):
             self.assertTrue(instance)
             self.notcontains('vxlan vlan 10 vni 10', dut)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/system/test_api_ipinterfaces.py
+++ b/test/system/test_api_ipinterfaces.py
@@ -131,5 +131,6 @@ class TestResourceIpinterfaces(DutSystemTest):
             self.assertIn('mtu 2000', config[0]['output'], 'dut=%s' % dut)
             dut.config('default interface %s' % intf)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/system/test_api_routemaps.py
+++ b/test/system/test_api_routemaps.py
@@ -273,5 +273,6 @@ class TestApiRoutemaps(DutSystemTest):
             self.assertTrue(result)
             self.assertEqual(None, api.get('TEST')['deny'][10]['continue'])
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/system/test_api_staticroute.py
+++ b/test/system/test_api_staticroute.py
@@ -287,5 +287,6 @@ class TestApiStaticroute(DutSystemTest):
                 distance=1, route_name='test3')
             self.assertTrue(result)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/system/test_api_stp.py
+++ b/test/system/test_api_stp.py
@@ -140,5 +140,6 @@ class TestApiStpInterfaces(DutSystemTest):
             result = resource.set_portfast_type(intf, 'normal')
             self.assertTrue(result, 'dut=%s' % dut)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/system/test_api_switchports.py
+++ b/test/system/test_api_switchports.py
@@ -132,5 +132,6 @@ class TestApiSwitchports(DutSystemTest):
                           config[0]['output'], 'dut=%s' % dut)
             dut.config('default interface %s' % intf)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/system/test_api_users.py
+++ b/test/system/test_api_users.py
@@ -177,5 +177,6 @@ class TestApiUsers(DutSystemTest):
             self.assertNotIn('username test sshkey %s' % TEST_SSH_KEY,
                              api.config)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/system/test_api_varp.py
+++ b/test/system/test_api_varp.py
@@ -232,5 +232,6 @@ class TestApiVarpInterfaces(DutSystemTest):
             self.assertNotIn('ip virtual-router address 1.1.1.21',
                              api.get_block('interface Vlan1000'))
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/unit/test_api_interfaces.py
+++ b/test/unit/test_api_interfaces.py
@@ -453,5 +453,6 @@ class TestApiVxlanInterface(EapiConfigUnitTest):
         func = function('remove_vtep', 'Vxlan1', '1.1.1.1', vlan='10')
         self.eapi_positive_config_test(func, cmds)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/unit/test_api_interfaces.py
+++ b/test/unit/test_api_interfaces.py
@@ -270,6 +270,7 @@ class TestApiPortchannelInterface(EapiConfigUnitTest):
                       lacp_mode='on', minimum_links=0,
                       lacp_fallback='disabled', lacp_timeout=90,
                       members=['Ethernet5', 'Ethernet6'])
+
         self.assertEqual(values, result)
 
     def test_set_minimum_links_with_value(self):
@@ -451,7 +452,6 @@ class TestApiVxlanInterface(EapiConfigUnitTest):
         cmds = ['interface Vxlan1', 'vxlan vlan 10 flood vtep remove 1.1.1.1']
         func = function('remove_vtep', 'Vxlan1', '1.1.1.1', vlan='10')
         self.eapi_positive_config_test(func, cmds)
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/unit/test_api_interfaces.py
+++ b/test/unit/test_api_interfaces.py
@@ -270,7 +270,6 @@ class TestApiPortchannelInterface(EapiConfigUnitTest):
                       lacp_mode='on', minimum_links=0,
                       lacp_fallback='disabled', lacp_timeout=90,
                       members=['Ethernet5', 'Ethernet6'])
-
         self.assertEqual(values, result)
 
     def test_set_minimum_links_with_value(self):

--- a/test/unit/test_api_interfaces.py
+++ b/test/unit/test_api_interfaces.py
@@ -295,6 +295,31 @@ class TestApiPortchannelInterface(EapiConfigUnitTest):
         func = function('set_minimum_links', 'Port-Channel1', disable=True)
         self.eapi_positive_config_test(func, cmds)
 
+    def test_set_lacp_timeout_with_value(self):
+        timeout = random_int(1, 16)
+        cmds = ['interface Port-Channel1', 'port-channel lacp fallback timeout %s' % timeout]
+        func = function('set_lacp_timeout', 'Port-Channel1', timeout)
+        self.eapi_positive_config_test(func, cmds)
+
+    def test_set_lacp_fallback_with_individual(self):
+        cmds = ['interface Port-Channel1', 'port-channel lacp fallback individual']
+        func = function('set_lacp_fallback', 'Port-Channel1', 'individual')
+        self.eapi_positive_config_test(func, cmds)
+
+    def test_set_lacp_fallback_with_static(self):
+        cmds = ['interface Port-Channel1', 'port-channel lacp fallback static']
+        func = function('set_lacp_fallback', 'Port-Channel1', 'static')
+        self.eapi_positive_config_test(func, cmds)
+
+    def test_set_lacp_fallback_with_disabled(self):
+        cmds = ['interface Port-Channel1', 'no port-channel lacp fallback']
+        func = function('set_lacp_fallback', 'Port-Channel1', 'disabled')
+        self.eapi_positive_config_test(func, cmds)
+
+    def test_set_lacp_fallback_invalid_mode(self):
+        func = function('set_lacp_fallback', 'Port-Channel1', random_string())
+        self.eapi_negative_config_test(func)
+
     def test_get_lacp_mode(self):
         result = self.instance.get_lacp_mode('Port-Channel1')
         self.assertEqual(result, 'on')

--- a/test/unit/test_api_interfaces.py
+++ b/test/unit/test_api_interfaces.py
@@ -268,6 +268,7 @@ class TestApiPortchannelInterface(EapiConfigUnitTest):
         values = dict(name='Port-Channel1', type='portchannel',
                       description=None, shutdown=False,
                       lacp_mode='on', minimum_links=0,
+                      lacp_fallback='disabled', lacp_timeout=90,
                       members=['Ethernet5', 'Ethernet6'])
 
         self.assertEqual(values, result)

--- a/test/unit/test_api_ipinterfaces.py
+++ b/test/unit/test_api_ipinterfaces.py
@@ -134,5 +134,6 @@ class TestApiIpinterfaces(EapiConfigUnitTest):
                 func = function('set_mtu', intf, value)
                 self.eapi_positive_config_test(func, cmds)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/unit/test_api_ospf.py
+++ b/test/unit/test_api_ospf.py
@@ -132,6 +132,7 @@ class TestApiNegOspf(EapiConfigUnitTest):
         result = self.instance.delete()
         self.assertTrue(result)
 
+
 if __name__ == '__main__':
     unittest.main()
 

--- a/test/unit/test_api_routemaps.py
+++ b/test/unit/test_api_routemaps.py
@@ -154,5 +154,6 @@ class TestApiRoutemaps(EapiConfigUnitTest):
         func = function('set_description', 'TEST', 'permit', 10, value=None)
         self.eapi_positive_config_test(func, cmds)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/unit/test_api_switchports.py
+++ b/test/unit/test_api_switchports.py
@@ -201,5 +201,6 @@ class TestApiSwitchports(EapiConfigUnitTest):
             func = function('remove_trunk_group', intf, 'foo')
             self.eapi_positive_config_test(func, cmds)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/unit/test_api_system.py
+++ b/test/unit/test_api_system.py
@@ -98,5 +98,6 @@ class TestApiSystem(EapiConfigUnitTest):
         cmds = 'no banner motd'
         self.eapi_positive_config_test(func, cmds)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/unit/test_api_varp.py
+++ b/test/unit/test_api_varp.py
@@ -146,5 +146,6 @@ class TestApiVarpInterfaces(EapiConfigUnitTest):
         cmds = ['interface Vlan4001', 'no ip virtual-router address']
         self.eapi_positive_config_test(func, cmds)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/unit/test_api_vlans.py
+++ b/test/unit/test_api_vlans.py
@@ -150,5 +150,6 @@ class TestApiVlans(EapiConfigUnitTest):
         func = function('remove_trunk_group', vid, tg)
         self.eapi_positive_config_test(func, cmds)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/unit/test_client.py
+++ b/test/unit/test_client.py
@@ -116,7 +116,7 @@ class TestNode(unittest.TestCase):
     def test_config_with_multiple_multilines(self):
         commands = [random_string(),
                     ('banner login MULTILINE:This is a new banner\n'
-                    'with different lines!!!'),
+                     'with different lines!!!'),
                     random_string()]
 
         self.node.run_commands = Mock(return_value=[{}, {}, {}, {}])


### PR DESCRIPTION
This should help to configure LACP fallback in EOS https://eos.arista.com/configuring-port-channel-lacp-fallback-on-arista-switches/