### PR TITLE
Add support for autoComplete parameter. Issue 119

### DIFF
--- a/pyeapi/eapilib.py
+++ b/pyeapi/eapilib.py
@@ -251,7 +251,7 @@ class EapiConnection(object):
         _LOGGER.debug('Autentication string is: {}'.format(self._auth))
 
 
-    def request(self, commands, encoding=None, reqid=None):
+    def request(self, commands, encoding=None, reqid=None, **kwargs):
         """Generates an eAPI request object
 
         This method will take a list of EOS commands and generate a valid
@@ -290,6 +290,8 @@ class EapiConnection(object):
         commands = make_iterable(commands)
         reqid = id(self) if reqid is None else reqid
         params = {"version": 1, "cmds": commands, "format": encoding}
+        if 'autoComplete' in kwargs:
+            params["autoComplete"] = kwargs["autoComplete"]
         return json.dumps({"jsonrpc": "2.0", "method": "runCmds",
                            "params": params, "id": str(reqid)})
 
@@ -393,6 +395,11 @@ class EapiConnection(object):
 
             if 'error' in decoded:
                 (code, msg, err, out) = self._parse_error_message(decoded)
+                if "unexpected keyword argument 'autoComplete'" in msg:
+                    auto_msg = ("autoComplete parameter is not supported in"
+                                " this version of EOS.")
+                    _LOGGER.error(auto_msg)
+                    msg = msg + ". " + auto_msg
                 raise CommandError(code, msg, command_error=err, output=out)
 
             return decoded

--- a/test/unit/test_eapilib.py
+++ b/test/unit/test_eapilib.py
@@ -110,7 +110,6 @@ class TestEapiConnection(unittest.TestCase):
         with self.assertRaises(pyeapi.eapilib.ConnectionError):
             instance.send('test')
 
-
     def test_send_raises_command_error(self):
         error = dict(code=9999, message='test', data=[{'errors': ['test']}])
         response_dict = dict(jsonrpc='2.0', error=error, id=id(self))
@@ -125,6 +124,41 @@ class TestEapiConnection(unittest.TestCase):
 
         with self.assertRaises(pyeapi.eapilib.CommandError):
             instance.send('test')
+
+    def test_send_raises_autocomplete_command_error(self):
+        message = "runCmds() got an unexpected keyword argument 'autoComplete'"
+        error = dict(code=9999, message=message, data=[{'errors': ['test']}])
+        response_dict = dict(jsonrpc='2.0', error=error, id=id(self))
+        response_json = json.dumps(response_dict)
+
+        mock_transport = Mock(name='transport')
+        mockcfg = {'getresponse.return_value.read.return_value': response_json}
+        mock_transport.configure_mock(**mockcfg)
+
+        instance = pyeapi.eapilib.EapiConnection()
+        instance.transport = mock_transport
+
+        try:
+            instance.send('test')
+        except pyeapi.eapilib.CommandError as error:
+            match = ("autoComplete parameter is not supported in this version"
+                     " of EOS.")
+            self.assertIn(match, error.message)
+
+    def test_request_adds_autocomplete(self):
+        instance = pyeapi.eapilib.EapiConnection()
+        request = instance.request(['sh ver'], encoding='json',
+                                   autoComplete=True)
+        data = json.loads(request)
+        self.assertIn('autoComplete', data['params'])
+
+    def test_request_ignores_unknown_param(self):
+        instance = pyeapi.eapilib.EapiConnection()
+        request = instance.request(['sh ver'], encoding='json',
+                                   unknown=True)
+        data = json.loads(request)
+        self.assertNotIn('unknown', data['params'])
+
 
 class TestCommandError(unittest.TestCase):
 


### PR DESCRIPTION
Support autoComplete parameter when using execute from a connection.