### PR TITLE
Adding vrf option to _build_command in staticroute

### DIFF
--- a/pyeapi/api/staticroute.py
+++ b/pyeapi/api/staticroute.py
@@ -303,6 +303,7 @@ class StaticRoute(EntityCollection):
             ip_dest (string): The ip address of the destination in the
                 form of A.B.C.D/E
             next_hop (string): The next hop interface or ip address
+            **kwargs['vrf'] (string): The vrf for this route
             **kwargs['next_hop_ip'] (string): The next hop address on
                 destination interface
             **kwargs['distance'] (string): Administrative distance for this
@@ -313,8 +314,11 @@ class StaticRoute(EntityCollection):
         Returns the ip route command string to be sent to the switch for
         the given set of parameters.
         """
-
-        commands = "ip route %s %s" % (ip_dest, next_hop)
+        vrf = kwargs.get('vrf', None)
+        if vrf is not None:
+            commands = "ip route vrf %s %s %s" % (vrf, ip_dest, next_hop)
+        else:
+            commands = "ip route %s %s" % (ip_dest, next_hop)
 
         next_hop_ip = kwargs.get('next_hop_ip', None)
         distance = kwargs.get('distance', None)

--- a/test/system/test_api_staticroute.py
+++ b/test/system/test_api_staticroute.py
@@ -40,7 +40,7 @@ from testlib import random_int, random_string
 from systestlib import DutSystemTest
 
 NEXT_HOPS = ['Ethernet1', 'Ethernet2', 'Null0', 'IP']
-DISTANCES = TAGS = ROUTE_NAMES = [None, True]
+DISTANCES = TAGS = ROUTE_NAMES = VRF = [None, True]
 
 
 def _ip_addr():
@@ -76,6 +76,10 @@ def _route_name():
     return random_string(minchar=4, maxchar=10)
 
 
+def _vrf():
+    return random_string(minchar=4, maxchar=10)
+
+
 class TestApiStaticroute(DutSystemTest):
 
     def test_create(self):
@@ -86,26 +90,30 @@ class TestApiStaticroute(DutSystemTest):
             dut.config(['no ip routing delete-static-routes',
                         'ip routing'])
 
-            for t_distance in DISTANCES:
-                for t_tag in TAGS:
-                    for t_route_name in ROUTE_NAMES:
-                        ip_dest = _ip_addr()
-                        (next_hop, next_hop_ip) = _next_hop()
-                        distance = t_distance
-                        if distance is True:
-                            distance = _distance()
-                        tag = t_tag
-                        if tag is True:
-                            tag = _tag()
-                        route_name = t_route_name
-                        if route_name is True:
-                            route_name = _route_name()
+            for t_vrf in VRF:
+                for t_distance in DISTANCES:
+                    for t_tag in TAGS:
+                        for t_route_name in ROUTE_NAMES:
+                            ip_dest = _ip_addr()
+                            (next_hop, next_hop_ip) = _next_hop()
+                            distance = t_distance
+                            if distance is True:
+                                distance = _distance()
+                            tag = t_tag
+                            if tag is True:
+                                tag = _tag()
+                            route_name = t_route_name
+                            if route_name is True:
+                                route_name = _route_name()
+                            vrf = t_vrf
+                            if vrf is True:
+                                vrf = _vrf()
 
-                        result = dut.api('staticroute').create(
-                            ip_dest, next_hop, next_hop_ip=next_hop_ip,
-                            distance=distance, tag=tag, route_name=route_name)
+                            result = dut.api('staticroute').create(
+                                ip_dest, next_hop, next_hop_ip=next_hop_ip,
+                                distance=distance, tag=tag, route_name=route_name, vrf=vrf)
 
-                        self.assertTrue(result)
+                            self.assertTrue(result)
 
     def test_get(self):
         # Validate the get function returns the exact value that
@@ -206,26 +214,30 @@ class TestApiStaticroute(DutSystemTest):
             dut.config(['no ip routing delete-static-routes',
                         'ip routing'])
 
-            for t_distance in DISTANCES:
-                for t_tag in TAGS:
-                    for t_route_name in ROUTE_NAMES:
-                        ip_dest = _ip_addr()
-                        (next_hop, next_hop_ip) = _next_hop()
-                        distance = t_distance
-                        if distance is True:
-                            distance = _distance()
-                        tag = t_tag
-                        if tag is True:
-                            tag = _tag()
-                        route_name = t_route_name
-                        if route_name is True:
-                            route_name = _route_name()
+            for t_vrf in VRF:
+                for t_distance in DISTANCES:
+                    for t_tag in TAGS:
+                        for t_route_name in ROUTE_NAMES:
+                            ip_dest = _ip_addr()
+                            (next_hop, next_hop_ip) = _next_hop()
+                            distance = t_distance
+                            if distance is True:
+                                distance = _distance()
+                            tag = t_tag
+                            if tag is True:
+                                tag = _tag()
+                            route_name = t_route_name
+                            if route_name is True:
+                                route_name = _route_name()
+                            vrf = t_vrf
+                            if vrf is True:
+                                vrf = _vrf()
 
-                        result = dut.api('staticroute').delete(
-                            ip_dest, next_hop, next_hop_ip=next_hop_ip,
-                            distance=distance, tag=tag, route_name=route_name)
+                            result = dut.api('staticroute').delete(
+                                ip_dest, next_hop, next_hop_ip=next_hop_ip,
+                                distance=distance, tag=tag, route_name=route_name, vrf=vrf)
 
-                        self.assertTrue(result)
+                            self.assertTrue(result)
 
     def test_default(self):
         # Validate the default function returns without an error
@@ -238,26 +250,30 @@ class TestApiStaticroute(DutSystemTest):
             dut.config(['no ip routing delete-static-routes',
                         'ip routing'])
 
-            for t_distance in DISTANCES:
-                for t_tag in TAGS:
-                    for t_route_name in ROUTE_NAMES:
-                        ip_dest = _ip_addr()
-                        (next_hop, next_hop_ip) = _next_hop()
-                        distance = t_distance
-                        if distance is True:
-                            distance = _distance()
-                        tag = t_tag
-                        if tag is True:
-                            tag = _tag()
-                        route_name = t_route_name
-                        if route_name is True:
-                            route_name = _route_name()
+            for t_vrf in VRF:
+                for t_distance in DISTANCES:
+                    for t_tag in TAGS:
+                        for t_route_name in ROUTE_NAMES:
+                            ip_dest = _ip_addr()
+                            (next_hop, next_hop_ip) = _next_hop()
+                            distance = t_distance
+                            if distance is True:
+                                distance = _distance()
+                            tag = t_tag
+                            if tag is True:
+                                tag = _tag()
+                            route_name = t_route_name
+                            if route_name is True:
+                                route_name = _route_name()
+                            vrf = t_vrf
+                            if vrf is True:
+                                vrf = _vrf()
 
-                        result = dut.api('staticroute').default(
-                            ip_dest, next_hop, next_hop_ip=next_hop_ip,
-                            distance=distance, tag=tag, route_name=route_name)
+                            result = dut.api('staticroute').default(
+                                ip_dest, next_hop, next_hop_ip=next_hop_ip,
+                                distance=distance, tag=tag, route_name=route_name, vrf=vrf)
 
-                        self.assertTrue(result)
+                            self.assertTrue(result)
 
     def test_set_tag(self):
         # Validate the set_tag function returns without an error

--- a/test/unit/test_api_staticroute.py
+++ b/test/unit/test_api_staticroute.py
@@ -44,7 +44,7 @@ import pyeapi.api.staticroute
 IP_DESTS = ['11.111.11.0/24', '222.22.222.0/24', '33.34.35.0/24']
 NEXT_HOPS = [('Ethernet1', '3.3.3.3'), ('Ethernet2', '2.2.2.2'),
              ('Null0', None), ('44.44.44.0', None)]
-DISTANCES = TAGS = ROUTE_NAMES = [None, True]
+DISTANCES = TAGS = ROUTE_NAMES = VRF = [None, True]
 
 
 class TestApiStaticroute(EapiConfigUnitTest):
@@ -162,12 +162,16 @@ class TestApiStaticroute(EapiConfigUnitTest):
             route_name = choice(ROUTE_NAMES)
             if route_name:
                 route_name = random_string(minchar=4, maxchar=10)
+            vrf = choice(VRF)
+            if vrf:
+                vrf = random_string(minchar=4, maxchar=10)
 
             func = function('create', ip_dest, next_hop,
                             next_hop_ip=next_hop_ip,
                             distance=distance,
                             tag=tag,
-                            route_name=route_name)
+                            route_name=route_name,
+                            vrf=vrf)
 
             # Build the expected string for comparison
             # A value of None will default to an empty string, and
@@ -181,9 +185,14 @@ class TestApiStaticroute(EapiConfigUnitTest):
                 cmd_tag = " tag %d" % tag
             if route_name is not None:
                 cmd_route_name = " name %s" % route_name
-            cmds = "ip route %s %s%s%s%s%s" % \
-                   (ip_dest, next_hop, cmd_next_hop_ip, cmd_distance,
-                    cmd_tag, cmd_route_name)
+            if vrf:
+                cmds = "ip route vrf %s %s %s%s%s%s%s" % \
+                    (vrf, ip_dest, next_hop, cmd_next_hop_ip, cmd_distance,
+                        cmd_tag, cmd_route_name)
+            else:
+                cmds = "ip route %s %s%s%s%s%s" % \
+                    (ip_dest, next_hop, cmd_next_hop_ip, cmd_distance,
+                        cmd_tag, cmd_route_name)
 
             self.eapi_positive_config_test(func, cmds)
 
@@ -201,12 +210,16 @@ class TestApiStaticroute(EapiConfigUnitTest):
             route_name = choice(ROUTE_NAMES)
             if route_name:
                 route_name = random_string(minchar=4, maxchar=10)
+            vrf = choice(VRF)
+            if vrf:
+                vrf = random_string(minchar=4, maxchar=10)
 
             func = function('delete', ip_dest, next_hop,
                             next_hop_ip=next_hop_ip,
                             distance=distance,
                             tag=tag,
-                            route_name=route_name)
+                            route_name=route_name,
+                            vrf=vrf)
 
             # Build the expected string for comparison
             # A value of None will default to an empty string, and
@@ -220,9 +233,14 @@ class TestApiStaticroute(EapiConfigUnitTest):
                 cmd_tag = " tag %d" % tag
             if route_name is not None:
                 cmd_route_name = " name %s" % route_name
-            cmds = "no ip route %s %s%s%s%s%s" % \
-                   (ip_dest, next_hop, cmd_next_hop_ip, cmd_distance,
-                    cmd_tag, cmd_route_name)
+            if vrf:
+                cmds = "no ip route vrf %s %s %s%s%s%s%s" % \
+                    (vrf, ip_dest, next_hop, cmd_next_hop_ip, cmd_distance,
+                        cmd_tag, cmd_route_name)
+            else:
+                cmds = "no ip route %s %s%s%s%s%s" % \
+                    (ip_dest, next_hop, cmd_next_hop_ip, cmd_distance,
+                        cmd_tag, cmd_route_name)
 
             self.eapi_positive_config_test(func, cmds)
 
@@ -240,12 +258,16 @@ class TestApiStaticroute(EapiConfigUnitTest):
             route_name = choice(ROUTE_NAMES)
             if route_name:
                 route_name = random_string(minchar=4, maxchar=10)
+            vrf = choice(VRF)
+            if vrf:
+                vrf = random_string(minchar=4, maxchar=10)
 
             func = function('default', ip_dest, next_hop,
                             next_hop_ip=next_hop_ip,
                             distance=distance,
                             tag=tag,
-                            route_name=route_name)
+                            route_name=route_name,
+                            vrf=vrf)
 
             # Build the expected string for comparison
             # A value of None will default to an empty string, and
@@ -259,9 +281,14 @@ class TestApiStaticroute(EapiConfigUnitTest):
                 cmd_tag = " tag %d" % tag
             if route_name is not None:
                 cmd_route_name = " name %s" % route_name
-            cmds = "default ip route %s %s%s%s%s%s" % \
-                   (ip_dest, next_hop, cmd_next_hop_ip, cmd_distance,
-                    cmd_tag, cmd_route_name)
+            if vrf:
+                cmds = "default ip route vrf %s %s %s%s%s%s%s" % \
+                    (vrf, ip_dest, next_hop, cmd_next_hop_ip, cmd_distance,
+                        cmd_tag, cmd_route_name)
+            else:
+                cmds = "default ip route %s %s%s%s%s%s" % \
+                    (ip_dest, next_hop, cmd_next_hop_ip, cmd_distance,
+                        cmd_tag, cmd_route_name)
 
             self.eapi_positive_config_test(func, cmds)
 


### PR DESCRIPTION
Hello,

Currently the `staticroute` API module provides method for creating and deleting (among others) static routes but it doesn't support **VRFs**. This PR is basically to add the `kwargs["vrf"]` option to the `_build_command` method of the module.

I believe there is a bigger issue related to adding VRF support for commands on https://github.com/arista-eosplus/pyeapi/issues/104 but its been idle for a while now, so I wanted to submit this small/simple PR to add some support for static routes module.

Thanks!