### PR TITLE
Inorrect import from 'collections' will stop working in Python 3.9

### DIFF
--- a/pyeapi/utils.py
+++ b/pyeapi/utils.py
@@ -170,7 +170,7 @@ def make_iterable(value):
     if isinstance(value, str) or isinstance(value, dict):
         value = [value]
 
-    if not isinstance(value, collections.Iterable):
+    if not isinstance(value, collections.abc.Iterable):
         raise TypeError('value must be an iterable object')
 
     return value


### PR DESCRIPTION
Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
Solving #195