### PR TITLE
#197 - updated vlans.getall() to handle vlan groupings

### DIFF
--- a/pyeapi/api/vlans.py
+++ b/pyeapi/api/vlans.py
@@ -166,7 +166,8 @@ class Vlans(EntityCollection):
             A dict object of Vlan attributes
 
         """
-        vlans_re = re.compile(r'(?<=^vlan\s)(\d+)', re.M)
+        # regex to find standalone and grouped (ranged, enumerated) vlans (#197)
+        vlans_re = re.compile(r'(?<=^vlan\s)[\d,\-]+', re.M)
 
         response = dict()
         for vid in vlans_re.findall(self.config):


### PR DESCRIPTION
if vlans in config are grouped, e.g.:
```
vlan 509-510,512
   ...
```
`getall()` should be able to match such case as well