### PR TITLE
updated vlans.get() to return range/list of vlan ids

### DIFF
--- a/pyeapi/api/vlans.py
+++ b/pyeapi/api/vlans.py
@@ -54,6 +54,7 @@ import re
 from pyeapi.api import EntityCollection
 from pyeapi.utils import make_iterable
 
+VLAN_ID_RE = re.compile(r'(?:vlan\s)(?P<value>.*)$', re.M)
 NAME_RE = re.compile(r'(?:name\s)(?P<value>.*)$', re.M)
 STATE_RE = re.compile(r'(?:state\s)(?P<value>.*)$', re.M)
 TRUNK_GROUP_RE = re.compile(r'(?:trunk\sgroup\s)(?P<value>.*)$', re.M)
@@ -104,12 +105,28 @@ class Vlans(EntityCollection):
         if not config:
             return None
 
-        response = dict(vlan_id=value)
+        response = dict(vlan_id=self._parse_vlan_id(config))
         response.update(self._parse_name(config))
         response.update(self._parse_state(config))
         response.update(self._parse_trunk_groups(config))
 
         return response
+
+    def _parse_vlan_id(self, config):
+        """ _parse_vlan_id scans the provided configuration block and extracts
+        the vlan id.  The config block is expected to always return the
+        vlan id.  The return dict is intended to be merged into the response
+        dict.
+
+        Args:
+            config (str): The vlan configuration block from the nodes running
+                configuration
+
+        Returns:
+            Str: vlan id (or range/list of vlan ids)
+        """
+        value = VLAN_ID_RE.search(config).group('value')
+        return value
 
     def _parse_name(self, config):
         """ _parse_name scans the provided configuration block and extracts

--- a/test/fixtures/running_config.text
+++ b/test/fixtures/running_config.text
@@ -394,6 +394,11 @@ vlan 100
    state active
    no private-vlan
 !
+vlan 200-202,204
+   name grouping
+   state active
+   no private-vlan
+!
 vlan 300
    name VLAN0300
    state active

--- a/test/unit/test_api_vlans.py
+++ b/test/unit/test_api_vlans.py
@@ -63,13 +63,19 @@ class TestApiVlans(EapiConfigUnitTest):
                     trunk_groups=[])
         self.assertEqual(vlan, result)
 
+        # ensure capturing grouppped vlans
+        result = self.instance.get('200-.*')
+        vlan = dict(vlan_id='200-202,204', name='grouping', state='active',
+                    trunk_groups=[])
+        self.assertEqual(vlan, result)
+
     def test_get_not_configured(self):
         self.assertIsNone(self.instance.get('1000'))
 
     def test_getall(self):
         result = self.instance.getall()
         self.assertIsInstance(result, dict)
-        self.assertEqual(len(result), 4)
+        self.assertEqual(len(result), 5)
 
     def test_vlan_functions(self):
         for name in ['create', 'delete', 'default']:


### PR DESCRIPTION
1. updated vlans.get() to return range/list of vlan ids (instead of input regex), e.g.:
```
vlans = connect.api('vlans')
vlans.get('200-.*')
{'vlan_id': '200-202,204', 'name': 'grouping', 'state': 'active', 'trunk_groups': []}
```
\- `vlan_id` now is resolved to the vlan line in config (`200-202,204`), rather than user's `200-.*`

2. updated relevant unit test