### PR TITLE
Support session-based authorization

### DIFF
--- a/pyeapi/client.py
+++ b/pyeapi/client.py
@@ -110,6 +110,7 @@ from pyeapi.utils import load_module, make_iterable, debug
 
 from pyeapi.eapilib import HttpEapiConnection, HttpsEapiConnection
 from pyeapi.eapilib import HttpsEapiCertConnection
+from pyeapi.eapilib import HttpEapiSessionConnection, HttpsEapiSessionConnection
 from pyeapi.eapilib import SocketEapiConnection, HttpLocalEapiConnection
 from pyeapi.eapilib import CommandError
 
@@ -119,8 +120,10 @@ TRANSPORTS = {
     'socket': SocketEapiConnection,
     'http_local': HttpLocalEapiConnection,
     'http': HttpEapiConnection,
+    'http_session': HttpEapiSessionConnection,
     'https': HttpsEapiConnection,
-    'https_certs': HttpsEapiCertConnection
+    'https_certs': HttpsEapiCertConnection,
+    'https_session': HttpsEapiSessionConnection,
 }
 
 DEFAULT_TRANSPORT = 'https'
@@ -404,8 +407,9 @@ def connect(transport=None, host='localhost', username='admin',
 
     Args:
         transport (str): Specifies the type of connection transport to use.
-            Valid values for the connection are socket, http_local, http, and
-            https.  The default value is specified in DEFAULT_TRANSPORT
+            Valid values for the connection are socket, http_local, http,
+            https, https_certs, http_session, and https_session.  The default
+            value is specified in DEFAULT_TRANSPORT
         host (str): The IP addres or DNS host name of the connection device.
             The default value is 'localhost'
         username (str): The username to pass to the device to authenticate

--- a/pyeapi/eapilib.py
+++ b/pyeapi/eapilib.py
@@ -309,14 +309,13 @@ class EapiConnection(object):
             # For Python 3.x
             _auth_bin = base64.encodebytes(_auth_text.encode())
             _auth = _auth_bin.decode()
-            _auth = _auth.replace('\n', '')
-            self._auth = _auth
         else:
             # For Python 2.7
-            _auth = base64.encodestring(_auth_text)
-            self._auth = str(_auth).replace('\n', '')
+            _auth = str(base64.encodestring(_auth_text))
+        _auth = _auth.replace('\n', '')
+        self._auth = ("Authorization", "Basic %s" % _auth)
 
-        _LOGGER.debug('Autentication string is: {}:***'.format(username))
+        _LOGGER.debug('Authentication string is: {}:***'.format(username))
 
     def request(self, commands, encoding=None, reqid=None, **kwargs):
         """Generates an eAPI request object
@@ -443,8 +442,7 @@ class EapiConnection(object):
             self.transport.putheader('Content-length', '%d' % len(data))
 
             if self._auth:
-                self.transport.putheader('Authorization',
-                                         'Basic %s' % self._auth)
+                self.transport.putheader(*self._auth)
 
             if int(sys.version[0]) > 2:
                 # For Python 3.x compatibility


### PR DESCRIPTION
Create a Session API mixin for Http and Https connection methods that
uses the /login endpoint to store a Cookie for all future connections.
This is useful when using centralized AAA to reduce the load of repeated
command calls.

Note that the cookie does have a lifetime, and that the connection will
stop working once the cookie lifetime expires, unless the authentication
method is manually called again