### PR TITLE
fixed import warning in abstract module

### DIFF
--- a/pyeapi/api/abstract.py
+++ b/pyeapi/api/abstract.py
@@ -40,7 +40,7 @@ provide parent class for API implementations.  All API modules will
 ultimately derive from BaseEntity which provides some common functions to
 make building API modules easier.
 """
-from collections import Callable, Mapping
+from collections.abc import Callable, Mapping
 
 from pyeapi.eapilib import CommandError, ConnectionError
 from pyeapi.utils import make_iterable


### PR DESCRIPTION
fixed annoying import warning when running systest:
```
test_add_entry (test_api_acl.TestApiExtendedAcls) ... /Users/dlyssenko/Work/My Work/> 2. ship EOS with pyeAPI module (bug457347)/pyeapi/pyeapi/api/abstract.py:43: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
  from collections import Callable, Mapping
```