### PR TITLE
Revert "Master"

### DIFF
--- a/docs/configfile.rst
+++ b/docs/configfile.rst
@@ -172,10 +172,6 @@ As the table above indicates, a pyeapi configuration file is required in
   username: admin
   password: admin
 
-.. Note:: avoid using ``localhost`` name in the connection description (i.e.: ``[connection:localhost]``). 
-          The name ``localhost`` is reserved solely for ``on-box`` connection method and it won't work when
-          connecting ``off-box``
-
 Using HTTPS with Certificates
 =============================
 


### PR DESCRIPTION
Reverts arista-eosplus/pyeapi#205
reverting it, as the changes first must be made in the _develop_ branch (as it appears, *readthedocs* is sourced from the _develop_ branch too)