### PR TITLE
Refactor deprecated unittest aliases for Python 3.11 compatibility.

### DIFF
--- a/test/system/test_client.py
+++ b/test/system/test_client.py
@@ -271,6 +271,9 @@ class TestNode(unittest.TestCase):
                 name = name.split(':')[1]
                 self.duts.append(pyeapi.client.connect_to(name))
 
+        if not hasattr(self, 'assertRegex'):
+            self.assertRegex = self.assertRegexpMatches
+
     def test_exception_trace(self):
         # Send commands that will return an error and validate the errors
 
@@ -321,7 +324,7 @@ class TestNode(unittest.TestCase):
                     self.assertIsNotNone(exc.command_error)
                     self.assertIsNotNone(exc.output)
                     self.assertIsNotNone(exc.commands)
-                    self.assertRegexpMatches(exc.message, regex)
+                    self.assertRegex(exc.message, regex)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The deprecated aliases have been removed in python/cpython#28268 . Use `assertRegex` in Python 3 when present and fallback to the Python 2 alias.