### PR TITLE
Address performance issues on section splitting

### DIFF
--- a/pyeapi/client.py
+++ b/pyeapi/client.py
@@ -94,6 +94,8 @@ from uuid import uuid4
 import os
 import re
 
+from functools import lru_cache
+
 try:
     # Try Python 3.x import first
     # Note: SafeConfigParser is deprecated and replaced by ConfigParser
@@ -621,6 +623,18 @@ class Node(object):
 
         return response
 
+    @lru_cache(maxsize=None)
+    def _chunkify(self, config):
+        sections = {}
+        key = None
+        for line in config.splitlines(keepends=True):
+            if not line.startswith(' '):
+                key = line.strip()
+                sections[key] = line
+            else:
+                sections[key] += line
+        return sections
+
     def section(self, regex, config='running_config'):
         """Returns a section of the config
 
@@ -636,18 +650,14 @@ class Node(object):
         """
         if config in ['running_config', 'startup_config']:
             config = getattr(self, config)
-        match = re.search(regex, config, re.M)
-        if not match:
+        chunked = self._chunkify(config)
+        r = re.compile(regex)
+        matching_keys = [k for k in chunked.keys() if r.match(k)]
+        if len(matching_keys) == 0:
             raise TypeError('config section not found')
-        block_start, line_end = match.regs[0]
-
-        match = re.search(r'^[^\s]', config[line_end:], re.M)
-        if not match:
-            raise TypeError('could not find end block')
-        _, block_end = match.regs[0]
-
-        block_end = line_end + block_end
-        return config[block_start:block_end]
+        matching_key = matching_keys[0]
+        match = chunked[matching_key]
+        return match
 
     def enable(self, commands, encoding='json', strict=False,
                send_enable=True, **kwargs):

--- a/test/unit/test_api_vrfs.py
+++ b/test/unit/test_api_vrfs.py
@@ -54,7 +54,7 @@ class TestApiVrfs(EapiConfigUnitTest):
                    ipv4_routing=True, ipv6_routing=False)
         self.assertEqual(vrf, result)
         result2 = self.instance.get('test')
-        vrf2 = dict(rd='200:500', vrf_name='test', description='!',
+        vrf2 = dict(rd='200:500', vrf_name='test', description='',
                     ipv4_routing=False, ipv6_routing=True)
         self.assertEqual(vrf2, result2)
 


### PR DESCRIPTION
Hi
The current parsing that splits the configuration from the device into sections is very slow. Running on a `DCS-7308-F` (with ~200 interfaces) this takes around **90 seconds**.

There are 2 reasons for that:
1- calling `getall()` on `api('switchports')` and `api('interfaces')` calls this twice
2- the regex approach is fairly slow, as it parses the whole config _for each interface_ (exacerbated by the first issue).

With this patch, the config is parsed once into sections. Looking at a flamegraph, it can still be improved however the impact on surrounding code would be a lot larger and the benefits are not that big (passing compiled objects or not compiling exact key matches like `interface Ethernet1`)

With this change applied, the parsing execution goes down to **2 seconds**.

The total time of execution for my device went from ~150 seconds to 27 seconds.
Further optimization by receiving an already compiled regex object when necessary (and a string for exact match when not) would bring this to 23 seconds.

This is important for me because I'm handling a fleet of 260 Arista devices and it adds up quite a bit when doing big changes.