### PR TITLE
Add option to not include defaults with node.running_config

### DIFF
--- a/pyeapi/client.py
+++ b/pyeapi/client.py
@@ -457,6 +457,8 @@ class Node(object):
         autorefresh (bool): If True, the running-config and startup-config are
             refreshed on config events.  If False, then the config properties
             must be manually refreshed.
+        config_defaults (bool): If True, the default config options will be
+            shown in the running-config output
         settings (dict): Provides access to the settings used to create the
             Node instance.
 
@@ -476,6 +478,7 @@ class Node(object):
 
         self._enablepwd = kwargs.get('enablepwd')
         self.autorefresh = kwargs.get('autorefresh', True)
+        self.config_defaults = kwargs.get('config_defaults', True)
         self.settings = kwargs
 
     def __str__(self):
@@ -492,7 +495,8 @@ class Node(object):
     def running_config(self):
         if self._running_config is not None:
             return self._running_config
-        self._running_config = self.get_config(params='all',
+        params = 'all' if self.config_defaults else None
+        self._running_config = self.get_config(params=params,
                                                as_string=True)
         return self._running_config
 

--- a/test/unit/test_client.py
+++ b/test/unit/test_client.py
@@ -333,6 +333,18 @@ class TestClient(unittest.TestCase):
         node = pyeapi.client.Node(None)
         self.assertTrue(hasattr(node, 'connection'))
 
+    @patch('pyeapi.client.Node.get_config')
+    def test_node_calls_running_config_with_all_by_default(self, get_config_mock):
+        node = pyeapi.client.Node(None)
+        _ = node.running_config
+        get_config_mock.assert_called_once_with(params='all', as_string=True)
+
+    @patch('pyeapi.client.Node.get_config')
+    def test_node_calls_running_config_without_params_if_config_defaults_false(self, get_config_mock):
+        node = pyeapi.client.Node(None, config_defaults=False)
+        _ = node.running_config
+        get_config_mock.assert_called_once_with(params=None, as_string=True)
+
     def test_node_returns_running_config(self):
         node = pyeapi.client.Node(None)
         get_config_mock = Mock(name='get_config')


### PR DESCRIPTION
Currently, the Node(conn).running_config always includes config defaults, this is not always wanted.
For example if you want to compare the running_config to the startup_config, it is easier to not have defaults included in the running_config.

With this option you can do something like this;
```
In [3]: conn = client.connect(**params)

In [4]: node = client.Node(conn, config_defaults=False)

In [5]: node.running_config.splitlines()[3:] == node.startup_config.splitlines()[4:]
Out[5]: True
```