### PR TITLE
fixing collection.Iterables in test_utils.py for py3.10

### DIFF
--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -1,3 +1,4 @@
+import sys
 import unittest
 import collections
 
@@ -5,6 +6,7 @@ from mock import patch, Mock
 
 import pyeapi.utils
 
+VER_LE_PY3_3 = sys.version_info <= (3, 3) 
 
 class TestUtils(unittest.TestCase):
 
@@ -23,18 +25,22 @@ class TestUtils(unittest.TestCase):
 
     def test_make_iterable_from_string(self):
         result = pyeapi.utils.make_iterable('test')
-        self.assertIsInstance(result, collections.Iterable)
+        self.assertIsInstance(result, 
+            collections.Iterable if VER_LE_PY3_3 else collections.abc.Iterable)
         self.assertEqual(len(result), 1)
 
     def test_make_iterable_from_unicode(self):
         result = pyeapi.utils.make_iterable(u'test')
-        self.assertIsInstance(result, collections.Iterable)
+        self.assertIsInstance(result, 
+            collections.Iterable if VER_LE_PY3_3 else collections.abc.Iterable)
         self.assertEqual(len(result), 1)
 
     def test_make_iterable_from_iterable(self):
         result = pyeapi.utils.make_iterable(['test'])
-        self.assertIsInstance(result, collections.Iterable)
+        self.assertIsInstance(result, 
+            collections.Iterable if VER_LE_PY3_3 else collections.abc.Iterable)
         self.assertEqual(len(result), 1)
+
 
     def test_make_iterable_raises_type_error(self):
         with self.assertRaises(TypeError):

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -6,7 +6,8 @@ from mock import patch, Mock
 
 import pyeapi.utils
 
-VER_LE_PY3_3 = sys.version_info <= (3, 3) 
+COLLECTIONS_ITERABLE = (collections.Iterable if sys.version_info <= (3, 3)
+    else collections.abc.Iterable)
 
 class TestUtils(unittest.TestCase):
 
@@ -25,20 +26,17 @@ class TestUtils(unittest.TestCase):
 
     def test_make_iterable_from_string(self):
         result = pyeapi.utils.make_iterable('test')
-        self.assertIsInstance(result, 
-            collections.Iterable if VER_LE_PY3_3 else collections.abc.Iterable)
+        self.assertIsInstance(result, COLLECTIONS_ITERABLE)
         self.assertEqual(len(result), 1)
 
     def test_make_iterable_from_unicode(self):
         result = pyeapi.utils.make_iterable(u'test')
-        self.assertIsInstance(result, 
-            collections.Iterable if VER_LE_PY3_3 else collections.abc.Iterable)
+        self.assertIsInstance(result, COLLECTIONS_ITERABLE)
         self.assertEqual(len(result), 1)
 
     def test_make_iterable_from_iterable(self):
         result = pyeapi.utils.make_iterable(['test'])
-        self.assertIsInstance(result, 
-            collections.Iterable if VER_LE_PY3_3 else collections.abc.Iterable)
+        self.assertIsInstance(result, COLLECTIONS_ITERABLE)
         self.assertEqual(len(result), 1)
 
 


### PR DESCRIPTION
in **python 3.10** `make unittest` is failing because `test/unit/test_utils.py` wasn't converted from using `collections.Iterable` into `collections.abc.Iterable`
\- Fixing that.