### PR TITLE
fixed issue where sphinx failed to generate API modules doc

### DIFF
--- a/docs/generate_modules.py
+++ b/docs/generate_modules.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+from __future__ import absolute_import, division, print_function
 
 from os import listdir, path, makedirs
 from os.path import isfile, join, exists
@@ -22,7 +23,7 @@ def get_module_names(p):
     mods = list()
     mods = [f.split('.')[0] for f in listdir(p)
             if isfile(join(p, f)) and not f.endswith('.pyc') and not f.startswith('__')]
-    print len(mods)
+    print( len(mods) )
     return mods
 
 def process_modules(modules):

--- a/pyeapi/api/abstract.py
+++ b/pyeapi/api/abstract.py
@@ -40,7 +40,11 @@ provide parent class for API implementations.  All API modules will
 ultimately derive from BaseEntity which provides some common functions to
 make building API modules easier.
 """
-from collections.abc import Callable, Mapping
+import sys
+if sys.version_info < (3, 3):
+    from collections import Callable, Mapping
+else:
+    from collections.abc import Callable, Mapping
 
 from pyeapi.eapilib import CommandError, ConnectionError
 from pyeapi.utils import make_iterable

--- a/pyeapi/utils.py
+++ b/pyeapi/utils.py
@@ -35,7 +35,11 @@ import importlib
 import inspect
 import logging
 import logging.handlers
-import collections
+if sys.version_info < (3, 3):
+    from collections import Iterable
+else:
+    from collections.abc import Iterable
+
 
 from itertools import tee
 
@@ -170,12 +174,8 @@ def make_iterable(value):
     if isinstance(value, str) or isinstance(value, dict):
         value = [value]
 
-    if sys.version_info <= (3, 3):
-        if not isinstance(value, collections.Iterable):
-            raise TypeError('value must be an iterable object')
-    else:
-        if not isinstance(value, collections.abc.Iterable):
-            raise TypeError('value must be an iterable object')
+    if not isinstance(value, Iterable):
+        raise TypeError('value must be an iterable object')
 
     return value
 

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -1,13 +1,13 @@
 import sys
 import unittest
-import collections
 
 from mock import patch, Mock
-
 import pyeapi.utils
 
-COLLECTIONS_ITERABLE = (collections.Iterable if sys.version_info <= (3, 3)
-    else collections.abc.Iterable)
+if sys.version_info < (3, 3):
+    from collections import Iterable
+else:
+    from collections.abc import Iterable
 
 class TestUtils(unittest.TestCase):
 
@@ -26,17 +26,17 @@ class TestUtils(unittest.TestCase):
 
     def test_make_iterable_from_string(self):
         result = pyeapi.utils.make_iterable('test')
-        self.assertIsInstance(result, COLLECTIONS_ITERABLE)
+        self.assertIsInstance(result, Iterable)
         self.assertEqual(len(result), 1)
 
     def test_make_iterable_from_unicode(self):
         result = pyeapi.utils.make_iterable(u'test')
-        self.assertIsInstance(result, COLLECTIONS_ITERABLE)
+        self.assertIsInstance(result, Iterable)
         self.assertEqual(len(result), 1)
 
     def test_make_iterable_from_iterable(self):
         result = pyeapi.utils.make_iterable(['test'])
-        self.assertIsInstance(result, COLLECTIONS_ITERABLE)
+        self.assertIsInstance(result, Iterable)
         self.assertEqual(len(result), 1)
 
 


### PR DESCRIPTION
After fix #204, `sphinx` failed to build API modules docs (all of them) and after rebuilding on readthedocs - they all got published blank (for `devel` branch).
It's all b/c for documentation build `python2` is still used, which is unable to resolve `collections.abc`. Fixed that issue.
- plus made uniform changes across all other occurrences of `collection` module
- plus uplifted `generate_modules.py` - made it python3 ready

Ran manually unit-tests under 2.7 and 3.10 - all good
Built documentations manually under 2.7 and 3.10 - all good