### PR TITLE
removed password from showing in debugs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ VERSION := $(shell cat VERSION)
 all: clean check pep8 flake8 tests
 
 pep8:
-	pycodestyle -r --ignore=E402,E731,E501,E221,W291,W391,E302,E251,E203,W293,E231,E303,E201,E202,E225,E261,E241 pyeapi/ test/
+	pycodestyle -r --ignore=E402,E731,E501,E221,W291,W391,E302,E251,E203,W293,E231,E303,E201,E202,E225,E261,E241,E128 pyeapi/ test/
 
 pyflakes:
 	pyflakes pyeapi/ test/

--- a/pyeapi/eapilib.py
+++ b/pyeapi/eapilib.py
@@ -434,7 +434,7 @@ class EapiConnection(object):
         """
         try:
             _LOGGER.debug(
-                'Request content: {}'.format(self._sanitize_request( data )))
+                'Request content: {}'.format(self._sanitize_request( data )) )
             # debug('eapi_request: %s' % data)
 
             self.transport.putrequest('POST', '/command-api')
@@ -505,11 +505,15 @@ class EapiConnection(object):
 
     def _sanitize_request( self, data ):
         """remove user-sensitive input from data response"""
-        data_json = json.loads( data )
-        match = self._find_sub_json( data_json, {'cmd': 'enable', 'input':()} )
-        if match:
-            match.entry[ match.idx ][ 'input' ] = '<removed>'
-            return json.dumps( data_json )
+        try:
+            data_json = json.loads( data )
+            match = self._find_sub_json(
+                data_json, {'cmd': 'enable', 'input':()} )
+            if match:
+                match.entry[ match.idx ][ 'input' ] = '<removed>'
+                return json.dumps( data_json )
+        except ValueError:
+            pass
         return data
 
 

--- a/pyeapi/eapilib.py
+++ b/pyeapi/eapilib.py
@@ -523,7 +523,7 @@ class EapiConnection(object):
         A json label cannot be wildcarded. A single wildcard represent a single
         json entry. E.g.:
 
-            _find_sub_json( jsn, { 'foo'': () } )
+            _find_sub_json( jsn, { 'foo': () } )
 
         Returned value is a Match class with attributes:
         - entry: an iterable containing a matching `sbj`

--- a/pyeapi/eapilib.py
+++ b/pyeapi/eapilib.py
@@ -573,7 +573,7 @@ class EapiConnection(object):
                 else:
                     return Match( jsn, key )
             if is_iterable( val ):
-                match =  self._find_sub_json( val, sbj, instance )
+                match = self._find_sub_json( val, sbj, instance )
                 if match:
                     return match
         return None

--- a/pyeapi/eapilib.py
+++ b/pyeapi/eapilib.py
@@ -520,10 +520,10 @@ class EapiConnection(object):
     def _find_sub_json( self, jsn, sbj, instance=0 ):
         """finds a subset (sbj) in json. `sbj` must be a subset and json must
         not be atomic. Wildcard(s) in `sbj` can be specified with tuple type.
-        A json label canot be wildcarded. A single wildcard represent a single
+        A json label cannot be wildcarded. A single wildcard represent a single
         json entry. E.g.:
 
-            _find_sub_json( jsn, { "foo": () } )
+            _find_sub_json( jsn, { 'foo'': () } )
 
         Returned value is a Match class with attributes:
         - entry: an iterable containing a matching `sbj`
@@ -531,7 +531,7 @@ class EapiConnection(object):
         If no match found None is returned - that way is possible to get a
         reference to the sought json and modify it, e.g:
 
-            match = _find_sub_json( jsn, { 'foo'':(), 'bar': [123, (), ()] } )
+            match = _find_sub_json( jsn, { 'foo':(), 'bar': [123, (), ()] } )
             if match:
                 match.entry[ match.idx ][ 'foo' ] = 'bar'
 


### PR DESCRIPTION
When user enables debugs and configures dut to use enable password, the user password is showing up in clear text in the debugs when any commands gets executed. This commit masks the user input.
