### PR TITLE
enhanced `section` to match subsections and removed py2.7 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['2.7', '3.5', '3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10']
       fail-fast: false
     name: Test on Python ${{ matrix.python-version }}
     steps:

--- a/pyeapi/client.py
+++ b/pyeapi/client.py
@@ -665,15 +665,15 @@ class Node(object):
                 continue
             # new section is found (if key is not None)
             if key: # process prior (last recorded) section
-               section_lines = sections[key].splitlines()[ 1: ]
-               if len( section_lines ): # section may contain sub-sections, process
-                   ind = len( section_lines[0] ) - len( section_lines[0].lstrip() )
-                   if is_subsection_present( section_lines, ind ):
-                       sub_sections = self._chunkify( sections[key], indent=ind )
-                       sub_sections.update( sections )
-                       sections = sub_sections
-               elif indent > 0: # record only subsections
-                   del( sections[key] )
+                section_lines = sections[key].splitlines()[ 1: ]
+                if len( section_lines ): # section may contain sub-sections, process
+                    ind = len( section_lines[0] ) - len( section_lines[0].lstrip() )
+                    if is_subsection_present( section_lines, ind ):
+                        sub_sections = self._chunkify( sections[key], indent=ind )
+                        sub_sections.update( sections )
+                        sections = sub_sections
+                elif indent > 0: # record only subsections
+                    del sections[key]
             key = line.rstrip()
             sections[key] = line
         return sections

--- a/pyeapi/client.py
+++ b/pyeapi/client.py
@@ -655,23 +655,45 @@ class Node(object):
 
     @lru_cache(maxsize=None)
     def _chunkify( self, config, indent=0 ):
+        """parse device config and return a dict holding sections and
+        sub-sections:
+        - a section always begins with a line with zero indents,
+        - a sub-section always begins with an indented line
+        a (sub)section typically contains a begin line (with a lower indent)
+        and a body (with a higher indent). A section might be degenerative (no
+        body, just the section line itself), while sub-sections always contain
+        a sub-section line plus some body). E.g., here's a snippet of a section
+        dict:
+        { ...
+          'spanning-tree mode none': 'spanning-tree mode none\n',
+          ...
+          'mac security': 'mac security\n  profile PR\n    cipher aes256-gcm',
+          '   profile PR': '  profile PR\n    cipher aes256-gcm'
+          ... }
+
+        it's imperative that the most outer call is made with indent=0, as the
+        indent parameter defines processing of nested sub-sections, i.e., if
+        indent > 0, then it's a recursive call and `config` argument contains
+        last parsed (sub)section, which in turn may contain sub-sections
+        """
         def is_subsection_present( section, indent ):
             return any( [line[ indent ] == ' ' for line in section] )
         sections = {}
         key = None
         for line in config.splitlines( keepends=True )[ indent > 0: ]:
+            # indent > 0: no need processing subsection line, which is 1st line
             if line[ indent ] == ' ':  # section continuation
                 sections[key] += line
                 continue
             # new section is found (if key is not None)
             if key: # process prior (last recorded) section
-                section_lines = sections[key].splitlines()[ 1: ]
-                if len( section_lines ): # section may contain sub-sections, process
-                    ind = len( section_lines[0] ) - len( section_lines[0].lstrip() )
-                    if is_subsection_present( section_lines, ind ):
-                        sub_sections = self._chunkify( sections[key], indent=ind )
-                        sub_sections.update( sections )
-                        sections = sub_sections
+                lines = sections[key].splitlines()[ 1: ]
+                if len( lines ): # section may contain sub-sections
+                    ind = len( lines[0] ) - len( lines[0].lstrip() )
+                    if is_subsection_present( lines, ind ):
+                        subs = self._chunkify( sections[key], indent=ind )
+                        subs.update( sections )
+                        sections = subs
                 elif indent > 0: # record only subsections
                     del sections[key]
             key = line.rstrip()

--- a/pyeapi/client.py
+++ b/pyeapi/client.py
@@ -686,15 +686,15 @@ class Node(object):
                 sections[key] += line
                 continue
             # new section is found (if key is not None)
-            if key: # process prior (last recorded) section
+            if key:  # process prior (last recorded) section
                 lines = sections[key].splitlines()[ 1: ]
-                if len( lines ): # section may contain sub-sections
+                if len( lines ):  # section may contain sub-sections
                     ind = len( lines[0] ) - len( lines[0].lstrip() )
                     if is_subsection_present( lines, ind ):
                         subs = self._chunkify( sections[key], indent=ind )
                         subs.update( sections )
                         sections = subs
-                elif indent > 0: # record only subsections
+                elif indent > 0:  # record only subsections
                     del sections[key]
             key = line.rstrip()
             sections[key] = line


### PR DESCRIPTION
after PR #220 the `section()` call is able to mach on sections only and not on the sub-sections (sections does not have leading spaces, while sub-sections do).

This PR enhances the `section()` call so that it's possible to match on the sub-sections too. Here's an example. Consider the following config snippet:
```
logging event link-status global
!
mcs client
   shutdown
   !
   cvx secondary default
      shutdown
      no server host
      no source-interface
      heartbeat-interval 20
      heartbeat-timeout 60
      no ssl profile
      vrf default
!
```

the new behavior will be like this:
```
>>> c.section( 'event link-status' )
'logging event link-status global\n'
>>> 
>>> c.section( 'mcs client' )
'mcs client\n   shutdown\n   !\n   cvx secondary default\n      shutdown\n      no server host\n      no source-interface\n      heartbeat-interval 20\n      heartbeat-timeout 60\n      no ssl profile\n      vrf default\n'
>>> 
>>> c.section( 'cvx secondary' )
'   cvx secondary default\n      shutdown\n      no server host\n      no source-interface\n      heartbeat-interval 20\n      heartbeat-timeout 60\n      no ssl profile\n      vrf default\n'
>>> 
>>> c.section( 'heartbeat-timeout' )
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/dlyssenko/Work/My Work/> pyeapi @ Github support/ISSUE PR # - enhancing sectioin slipt and removing py2.7 from CI /pyeapi/pyeapi/client.py", line 700, in section
    raise TypeError('config section not found')
TypeError: config section not found
>>> 
``` 

Note on the section matching behavior:
 - if sub-section is not unique (e.g.: `ipv4`) then only the first matching occurrence will be found.
 - when matching, subsection's leading spaces matter, thus to avoid false positives matches it's better to specify it, e.g.: `c.section( '^ +cvx secondary' )`
