### PR TITLE
provisioning for CLI variants to handle deprecated cli trasnitions

### DIFF
--- a/pyeapi/api/abstract.py
+++ b/pyeapi/api/abstract.py
@@ -47,7 +47,7 @@ else:
     from collections.abc import Callable, Mapping
 
 from pyeapi.eapilib import CommandError
-from pyeapi.utils import make_iterable, CliVariants
+from pyeapi.utils import make_iterable
 
 
 class BaseEntity(object):
@@ -118,38 +118,17 @@ class BaseEntity(object):
 
         Args:
             commands (list): A list of commands to be sent to the node in
-                config mode. *list* may contain ``pyeapi.utils.CliVariants``
-                object, which provides alternative cli syntax, e.g.:
-                ``configure( pyeapi.utils.CliVariants(new_cli, old_cli) )``
+                config mode
 
         Returns:
             True if the commands are executed without exception otherwise
                 False is returned
         """
-        def non_variant_config( commands ):
-            try:
-                self.node.config( commands )
-                return True
-            except (CommandError):
-                return False
-
-        def variant_cli_idx( cmds ):
-            try:
-                return [ type(v) for v in cmds ].index( CliVariants )
-            except (ValueError):
-                return -1
-
-        idx = variant_cli_idx( commands )
-        if idx == -1:
-            return non_variant_config( commands )
-
-        # commands contain CliVariants obj, e.g.: [ 'cli', CliVariants, ... ]
-        for variant in commands[ idx ].variants:
-            cmd = commands[ :idx ] + variant + commands[idx + 1:]
-            if non_variant_config( cmd ):
-                return True
-        return False
-
+        try:
+            self.node.config(commands)
+            return True
+        except (CommandError):
+            return False
 
     def command_builder(self, string, value=None, default=None, disable=None):
         """Builds a command with keywords

--- a/pyeapi/client.py
+++ b/pyeapi/client.py
@@ -633,13 +633,14 @@ class Node(object):
             return cfg_call( commands, **kwargs )
 
         # commands contain CliVariants obj, e.g.: [ '...', CliVariants, ... ]
+        exp = None
         for variant in commands[ idx ].variants:
             cmd = commands[ :idx ] + variant + commands[ idx + 1: ]
             try:
                 return cfg_call( cmd, **kwargs )
             except (CommandError) as e:
-                pass
-        raise CommandError( e.message )
+                exp = (e.error_code, e.error_text)
+        raise CommandError( *exp )
 
     def _configure_terminal(self, commands, **kwargs):
         """Configures the node with the specified commands with leading
@@ -665,7 +666,7 @@ class Node(object):
         "configure session <session name>"
         """
         if not self._session_name:
-            raise CommandError('Not currently in a session')
+            raise CommandError(-1, 'Not currently in a session')
 
         commands = make_iterable(commands)
         commands = list(commands)

--- a/pyeapi/client.py
+++ b/pyeapi/client.py
@@ -613,8 +613,8 @@ class Node(object):
                 sequences, e.g.:
                 ``config( [cli1, CliVariants( cli2, cli3 ), cli4] )``
                 the example above can be translated into following sequence:
-               ``config( [cli1, cli2, cli4] )``
-               ``config( [cli1, cli3, cli4] )``
+                ``config( [cli1, cli2, cli4] )``
+                ``config( [cli1, cli3, cli4] )``
                 CliVariants accepts 2 or more arguments of str, list type, or
                 their mix. Each argument to CliVariants will be joined with the
                 rest of commands and all command sequences will be tried until

--- a/pyeapi/client.py
+++ b/pyeapi/client.py
@@ -633,14 +633,17 @@ class Node(object):
             return cfg_call( commands, **kwargs )
 
         # commands contain CliVariants obj, e.g.: [ '...', CliVariants, ... ]
-        exp = None
+        e = None
         for variant in commands[ idx ].variants:
             cmd = commands[ :idx ] + variant + commands[ idx + 1: ]
             try:
                 return cfg_call( cmd, **kwargs )
-            except (CommandError) as e:
-                exp = (e.error_code, e.error_text)
-        raise CommandError( *exp )
+            except (CommandError) as exp:
+                e = exp
+        # re-raising last occurred CommandError
+        raise CommandError( e.error_code, e.error_text, output=e.output,
+            commands=e.commands, command_error=e.command_error )
+
 
     def _configure_terminal(self, commands, **kwargs):
         """Configures the node with the specified commands with leading

--- a/pyeapi/utils.py
+++ b/pyeapi/utils.py
@@ -252,10 +252,10 @@ class CliVariants:
     Provides an interface for cli variants (typically to handle a transition
     period for a deprecated cli)
 
-    Instance must be initialized either with 2 (or more) str variants:
+    Instance must be initialized either with 2 or more str variants:
         ``CliVariants( 'new cli', 'legacy cli' )``,
-    or with 2 or more sequences of cli (or a mix):
-        ``CliVariants( ['new cli 1', 'new cli 2'], 'legacy cli' )``
+    or with 2 or more sequences of cli (or a mix of list and str types), e.g.:
+        ``CliVariants( ['new cli1', 'new cli2'], 'alt cli3', 'legacy cli4' )``
     """
     def __init__(self, *cli):
         assert len( cli ) >= 2, 'must be initialized with 2 or more arguments'

--- a/pyeapi/utils.py
+++ b/pyeapi/utils.py
@@ -171,7 +171,8 @@ def make_iterable(value):
         # Convert unicode values to strings for Python 2
         if isinstance(value, unicode):
             value = str(value)
-    if isinstance(value, str) or isinstance(value, dict):
+    if isinstance(value, str) or isinstance(
+            value, dict) or isinstance(value, CliVariants):
         value = [value]
 
     if not isinstance(value, Iterable):
@@ -244,3 +245,19 @@ def collapse_range(arg, value_delimiter=',', range_delimiter='-'):
         else:
             values.extend([v1])
     return [str(x) for x in values]
+
+
+class CliVariants:
+    """
+    Provides an interface for cli variants (typically to handle a transition
+    period for a deprecated cli)
+
+    Instance must be initialized either with 2 (or more) str variants:
+        ``CliVariants( 'new cli', 'legacy cli' )``,
+    or with 2 or more sequences of cli (or a mix):
+        ``CliVariants( ['new cli 1', 'new cli 2'], 'legacy cli' )``
+    """
+    def __init__(self, *cli):
+        assert len( cli ) >= 2, 'must be initialized with 2 or more arguments'
+        self.variants = [ v if not isinstance(v, str) and isinstance(v, Iterable)
+            else [v] for v in cli ]


### PR DESCRIPTION
There are 2 possible approaches:
1. rely on the EOS version check (`self.version_number`) and then handle it respectingly
2. provide a programmatic interface to handle CLI variants why try-and-fail approach, where newer CLI is tried first and on the failed syntax a legacy (older) cli is tried

each approach has pros and cons: 
 - for the 1st one, it's could be difficult to provide exact version matching for special and custom EOS versions.
 - for the 2nd, the cli fetching turnaround (when running a newer pyeapi on an older EOS) would be longer, due to handling a failing (newer) variant of CLI  

This enhancement takes 2nd approach as the tradeoff for it is deemed reasonable and the handling approach would be more universal and code-wise cleaner.
