### PR TITLE
Include error message in CommandError for internal exceptions

### DIFF
--- a/pyeapi/eapilib.py
+++ b/pyeapi/eapilib.py
@@ -115,7 +115,7 @@ class CommandError(EapiError):
     """
     def __init__(self, code, message, **kwargs):
         cmd_err = kwargs.get('command_error')
-        if int(code) in [1000, 1002, 1004]:
+        if int(code) in [1000, 1001, 1002, 1004]:
             msg_fmt = 'Error [{}]: {} [{}]'.format(code, message, cmd_err)
         else:
             # error code 1005: 'Command unauthorized: user has insufficient


### PR DESCRIPTION
Internal exceptions (error code 1001) currently do not have the actual error message included within `CommandError`, which hinders debugging.

Before
```
pyeapi.eapilib.CommandError: Error [1001]: CLI command 10 of 11 '   no shutdown' failed: internal error
```
After
```
pyeapi.eapilib.CommandError: Error [1001]: CLI command 10 of 11 '   no shutdown' failed: internal error [[Errno 13] Permission denied: '/usr/local/bin/foo']
```