### PR TITLE
some physical duts supports only up to 8 min-link values

### DIFF
--- a/test/system/test_api_interfaces.py
+++ b/test/system/test_api_interfaces.py
@@ -390,7 +390,7 @@ class TestPortchannelInterface(DutSystemTest):
 
     def test_minimum_links_valid(self):
         for dut in self.duts:
-            minlinks = random_int(1, 16)
+            minlinks = random_int(1, 8)  # some physical duts may have only 8 links
             dut.config(['no interface Port-Channel1',
                         'interface Port-Channel1'])
             result = dut.api('interfaces').set_minimum_links('Port-Channel1',


### PR DESCRIPTION
When testing against a pool of real duts, some duts (supporting only up to 8 min-links) fail the test, hence adopting the change.