### PR TITLE
fix for issue #286

### DIFF
--- a/pyeapi/client.py
+++ b/pyeapi/client.py
@@ -718,28 +718,87 @@ class Node(object):
         last parsed (sub)section, which in turn may contain sub-sections
         """
         def is_subsection_present( section, indent ):
-            return any( [line[ indent ] == ' ' for line in section] )
+            return any( line[ indent ] == ' ' for line in section )
+        def get_indent( line ):
+            return len( line ) - len( line.lstrip() )
         sections = {}
         key = None
+        banner = None
         for line in config.splitlines( keepends=True )[ indent > 0: ]:
-            # indent > 0: no need processing subsection line, which is 1st line
-            if line[ indent ] == ' ':  # section continuation
-                sections[key] += line
+            line_rs = line.rstrip()
+            if indent == 0:
+                if banner:
+                    sections[ banner ] += line
+                    if line == 'EOF\n':
+                        banner = None
+                    continue
+                if line.startswith( 'banner ' ):
+                    banner = line_rs
+                    sections[ banner ] = line
+                    continue
+            if get_indent( line_rs ) > indent:  # i.e. subsection line
+                # key is always expected to be set by now
+                sections[ key ] += line
                 continue
-            # new section is found (if key is not None)
-            if key:  # process prior (last recorded) section
-                lines = sections[key].splitlines()[ 1: ]
-                if len( lines ):  # section may contain sub-sections
-                    ind = len( lines[0] ) - len( lines[0].lstrip() )
-                    if is_subsection_present( lines, ind ):
-                        subs = self._chunkify( sections[key], indent=ind )
-                        subs.update( sections )
-                        sections = subs
-                elif indent > 0:  # record only subsections
-                    del sections[key]
-            key = line.rstrip()
-            sections[key] = line
+            subsection = sections.get( key, '' ).splitlines()[ 1: ]
+            if subsection:
+                sub_indent = get_indent( subsection[0] )
+                if is_subsection_present( subsection, sub_indent ):
+                    parsed = self._chunkify( sections[key], indent=sub_indent )
+                    parsed.update( sections )
+                    sections = parsed
+            key = line_rs
+            sections[ key ] = line
         return sections
+
+
+#    @lru_cache(maxsize=None)
+#    def _chunkify( self, config, indent=0 ):
+#        """parse device config and return a dict holding sections and
+#        sub-sections:
+#        - a section always begins with a line with zero indents,
+#        - a sub-section always begins with an indented line
+#        a (sub)section typically contains a begin line (with a lower indent)
+#        and a body (with a higher indent). A section might be degenerative (no
+#        body, just the section line itself), while sub-sections always contain
+#        a sub-section line plus some body). E.g., here's a snippet of a section
+#        dict:
+#        { ...
+#          'spanning-tree mode none': 'spanning-tree mode none\n',
+#          ...
+#          'mac security': 'mac security\n  profile PR\n    cipher aes256-gcm',
+#          '   profile PR': '  profile PR\n    cipher aes256-gcm'
+#          ... }
+#
+#        it's imperative that the most outer call is made with indent=0, as the
+#        indent parameter defines processing of nested sub-sections, i.e., if
+#        indent > 0, then it's a recursive call and `config` argument contains
+#        last parsed (sub)section, which in turn may contain sub-sections
+#        """
+#        def is_subsection_present( section, indent ):
+#            return any( [line[ indent ] == ' ' for line in section] )
+#        sections = {}
+#        key = None
+#        for line in config.splitlines( keepends=True )[ indent > 0: ]:
+#            # indent > 0: no need processing subsection line, which is 1st line
+#            if line[ indent ] == ' ':  # section continuation
+#                sections[key] += line
+#                continue
+#            # new section is found (if key is not None)
+#            if key:  # process prior (last recorded) section
+#                lines = sections[key].splitlines()[ 1: ]
+#                if len( lines ):  # section may contain sub-sections
+#                    ind = len( lines[0] ) - len( lines[0].lstrip() )
+#                    if is_subsection_present( lines, ind ):
+#                        subs = self._chunkify( sections[key], indent=ind )
+#                        subs.update( sections )
+#                        sections = subs
+#                elif indent > 0:  # record only subsections
+#                    del sections[key]
+#            key = line.rstrip()
+#            sections[key] = line
+#        return sections
+
 
     def section(self, regex, config='running_config'):
         """Returns a section of the config

--- a/test/fixtures/running_config.text
+++ b/test/fixtures/running_config.text
@@ -376,6 +376,13 @@ environment fan-speed auto
 !
 clock timezone US/Eastern
 !
+banner login
++++++++++++++++++++++++++++++++++++++++++
+              banner:
+         
+EOF
+!
+
 no virtual-cable
 !
 vlan 1


### PR DESCRIPTION
this PR fixes issue #286 

The issue has been introduced with PR#220 - that PR introduced cached parsing of the running config, which is mostly indent-structured text, however, we entirely overlooked a banner section.
Unlike the rest of the config, the banner section(s) is a free text (i.e. unstructured) and therefore may produce:
- false positive results
- failures
- rogue / bogus / phony sections.

The banner is now parsed into a separate section.