### PR TITLE
Switch to importlib for realoading

### DIFF
--- a/test/unit/test_client.py
+++ b/test/unit/test_client.py
@@ -32,7 +32,7 @@
 import sys
 import os
 import unittest
-import imp
+import importlib
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '../lib'))
 
@@ -227,7 +227,7 @@ class TestClient(unittest.TestCase):
     def setUp(self):
         if 'EAPI_CONF' in os.environ:
             del os.environ['EAPI_CONF']
-        imp.reload(pyeapi.client)
+        importlib.reload(pyeapi.client)
 
     def test_load_config_for_connection_with_filename(self):
         conf = get_fixture('eapi.conf')


### PR DESCRIPTION
Since 3.7, importlib has supported a reload method, and since 3.12 has removed the imp module entirely, we should switch to using importlib.