### PR TITLE
fixing system test issue where non-existent interface could be selected

### DIFF
--- a/test/lib/systestlib.py
+++ b/test/lib/systestlib.py
@@ -66,9 +66,15 @@ class DutSystemTest(unittest.TestCase):
 
 
 def random_interface(dut, exclude=None):
+    # interfaces read in 'show run all' and those actually present may differ,
+    # thus interface list must be picked from the actually present
+    if not getattr( random_interface, 'present', False ):
+        random_interface.present = dut.run_commands(
+            'show interfaces', send_enable=False )[ 0 ][ 'interfaces' ].keys()
     exclude = [] if exclude is None else exclude
     interfaces = dut.api('interfaces')
-    names = [name for name in list(interfaces.keys()) if name.startswith('Et')]
+    names = [ name for name in list(interfaces.keys()) if name.startswith('Et') ]
+    names = [ name for name in names if name in random_interface.present ]
 
     exclude_interfaces = dut.settings.get('exclude_interfaces', [])
     if exclude_interfaces:


### PR DESCRIPTION
1. Dut's API gets list of all interfaces in `/pyeapi/api/interfaces.py` - it read those from `show run all`.
2. However, some interfaces present in the 'config all' might not be present on the actual dut.
3. This might create an issue during sytem test if `random_interface ()` picks an interface which is not currently present on the dut.

this PR should fix the issue