### PR TITLE
fixing system test issue where mlag test fails on Ethernet1

### DIFF
--- a/test/system/test_api_interfaces.py
+++ b/test/system/test_api_interfaces.py
@@ -44,7 +44,7 @@ class TestResourceInterfaces(DutSystemTest):
 
     def test_get(self):
         for dut in self.duts:
-            intf = random_interface(dut)
+            intf = random_interface( dut, exclude=['Ethernet1'] )
             dut.config(['default interface %s' % intf,
                         'interface %s' % intf,
                         'description this is a test',


### PR DESCRIPTION
1. `test_api_mlag` runs after `test_api_interfaces`.  The latter selects a guinea-pig interface via `random_interface()` call
2. `test_api_mlag` always selects interface `Ethernet1` for its test. 
3. Thus, if `test_api_interfaces` picks `Ethernet1` by chance, it leaves it with flow-control configured, which breaks then mlag test

This trivial fix excludes  `Ethernet1` from being selected in `test_api_interfaces`