### PR TITLE
Update eapilib.py: allow pass any EAPI params to jsonrpc

### DIFF
--- a/pyeapi/eapilib.py
+++ b/pyeapi/eapilib.py
@@ -344,19 +344,14 @@ class EapiConnection(object):
         """
         commands = make_iterable(commands)
         reqid = id(self) if reqid is None else reqid
-        params = {'version': 1, 'cmds': commands, 'format': encoding}
-        streaming = False
-        if 'apiVersion' in kwargs:
-            params['version'] = kwargs['apiVersion']
-        if 'autoComplete' in kwargs:
-            params['autoComplete'] = kwargs['autoComplete']
-        if 'expandAliases' in kwargs:
-            params['expandAliases'] = kwargs['expandAliases']
-        if 'streaming' in kwargs:
-            streaming = kwargs['streaming']
-        return json.dumps({'jsonrpc': '2.0', 'method': 'runCmds',
+        streaming = kwargs.pop( 'streaming', False )
+        params = { 'version': kwargs.pop('apiVersion', 1), 
+            'format': kwargs.pop('format', encoding) }           
+        params.update( kwargs )
+        params.update({ 'cmds': commands })
+        return json.dumps( {'jsonrpc': '2.0', 'method': 'runCmds',
                            'params': params, 'id': str(reqid),
-                           'streaming': streaming})
+                           'streaming': streaming} )
 
     def send(self, data):
         """Sends the eAPI request to the destination node

--- a/pyeapi/eapilib.py
+++ b/pyeapi/eapilib.py
@@ -349,8 +349,8 @@ class EapiConnection(object):
             'format': kwargs.pop('format', encoding) }           
         params.update( kwargs )
         params.update({ 'cmds': commands })
-        params = { k:v for k,v in params.items() if k in 
-            ('version', 'cmds', 'autoComplete', 'expandAliases', 'timestamps' ) }
+        params = { k:v for k,v in params.items() if k in ('version',
+            'format', 'cmds', 'autoComplete', 'expandAliases', 'timestamps') }
         return json.dumps( {'jsonrpc': '2.0', 'method': 'runCmds',
                            'params': params, 'id': str(reqid),
                            'streaming': streaming} )

--- a/pyeapi/eapilib.py
+++ b/pyeapi/eapilib.py
@@ -349,6 +349,8 @@ class EapiConnection(object):
             'format': kwargs.pop('format', encoding) }           
         params.update( kwargs )
         params.update({ 'cmds': commands })
+        params = { k:v for k,v in params.items() if k in 
+            ('version', 'cmds', 'autoComplete', 'expandAliases', 'timestamps' ) }
         return json.dumps( {'jsonrpc': '2.0', 'method': 'runCmds',
                            'params': params, 'id': str(reqid),
                            'streaming': streaming} )


### PR DESCRIPTION
changed the way EAPI params passed to `jsonrpc`, while preserving currently existing (supported) syntax. This way a user can pass any EAPI parameters into `jsonrpc`