### PR TITLE
fix for issue #290 - allow passing key and cert file to the connect()

### DIFF
--- a/test/system/test_client.py
+++ b/test/system/test_client.py
@@ -323,7 +323,7 @@ class TestClient(unittest.TestCase):
                     password=dut.settings['password'], key_file=kf.name,
                     cert_file=cf.name, return_node=True)
                 res = node.enable( 'show version' )
-            self.assertIn( 'version', res[0]['result'] )
+                self.assertIn( 'version', res[0]['result'] )
 
 class TestNode(unittest.TestCase):
 

--- a/test/system/test_client.py
+++ b/test/system/test_client.py
@@ -311,8 +311,8 @@ class TestClient(unittest.TestCase):
 
     def test_secure_transport( self ):
         # create key and cert temp files
-        with ( tempfile.NamedTemporaryFile() as kf,
-                tempfile.NamedTemporaryFile() as cf ):
+        with tempfile.NamedTemporaryFile() as kf,\
+                tempfile.NamedTemporaryFile() as cf:
             kf.write( private_key.encode() )
             kf.flush()
             cf.write( certificate.encode() )

--- a/test/system/test_client.py
+++ b/test/system/test_client.py
@@ -311,7 +311,7 @@ class TestClient(unittest.TestCase):
 
     def test_secure_transport( self ):
         # create key and cert temp files
-        with tempfile.NamedTemporaryFile() as kf,\
+        with tempfile.NamedTemporaryFile() as kf, \
                 tempfile.NamedTemporaryFile() as cf:
             kf.write( private_key.encode() )
             kf.flush()


### PR DESCRIPTION
1. fixed issue #290 -  now private key and certificate can be passed as parameters to the pyeapi `connect()` method when `https_certs` transport is used
2. added system test to ensure transport `https_certs` works
