### PR TITLE
fix issue #318, plus deprecation for empty ssl.SSLContext() call

### DIFF
--- a/pyeapi/eapilib.py
+++ b/pyeapi/eapilib.py
@@ -219,8 +219,8 @@ class HTTPSCertConnection(HTTPSConnection):
 
     def __init__(self, path, host, port, key_file, cert_file, ca_file,
                  timeout=None):
-        # key_file & cert_file deprecated in Python 3.6 and removed in 3.12 so, don't pass those to
-        # HTTPSConnection.__init__() --
+        # key_file & cert_file deprecated in Python 3.6 and removed in 3.12
+        # so, don't pass those to HTTPSConnection.__init__() --
         # The SSL context with the client cert is built in connect() instead.
         HTTPSConnection.__init__(self, host)
         self.key_file = key_file
@@ -253,15 +253,15 @@ class HTTPSCertConnection(HTTPSConnection):
         if self._tunnel_host:
             self.sock = sock
             self._tunnel()
-        # empty call ssl.SSLContext() is deprecated since 3.10, thus handle is properly
-        # with PROTOCOL_TLS_CLIENT defaulting to check_hostname=True and
-        # verify_mode=CERT_REQUIRED.
-        # When no CA file is provided we disable server-certificate verification
+        # empty call ssl.SSLContext() is deprecated since 3.10, thus handle it
+        # properly with PROTOCOL_TLS_CLIENT defaulting to check_hostname=True
+        # and verify_mode=CERT_REQUIRED.
+        # When no CA file is provided disable server-certificate verification
         context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
         context.load_cert_chain(certfile=self.cert_file, keyfile=self.key_file)
         if self.ca_file:
-            # Server certificate verification enabled, below settings are defaults:
-            # (check_hostname=True, verify_mode=CERT_REQUIRED)
+            # Server certificate verification enabled, below settings are
+            # defaults: (check_hostname=True, verify_mode=CERT_REQUIRED)
             context.load_verify_locations(ca_certs=self.ca_file)
         else:
             # No CA file supplied: disable server certificate verification.
@@ -353,11 +353,11 @@ class EapiConnection(object):
         commands = make_iterable(commands)
         reqid = id(self) if reqid is None else reqid
         streaming = kwargs.pop( 'streaming', False )
-        params = { 'version': kwargs.pop('apiVersion', 1), 
-            'format': kwargs.pop('format', encoding) }           
+        params = { 'version': kwargs.pop('apiVersion', 1),
+            'format': kwargs.pop('format', encoding) }
         params.update( kwargs )
         params.update({ 'cmds': commands })
-        params = { k:v for k,v in params.items() if k in ('version',
+        params = { k: v for k, v in params.items() if k in ('version',
             'format', 'cmds', 'autoComplete', 'expandAliases', 'timestamps') }
         return json.dumps( {'jsonrpc': '2.0', 'method': 'runCmds',
                            'params': params, 'id': str(reqid),

--- a/pyeapi/eapilib.py
+++ b/pyeapi/eapilib.py
@@ -219,8 +219,10 @@ class HTTPSCertConnection(HTTPSConnection):
 
     def __init__(self, path, host, port, key_file, cert_file, ca_file,
                  timeout=None):
-        HTTPSConnection.__init__(self, host, key_file=key_file,
-                                 cert_file=cert_file)
+        # key_file & cert_file deprecated in Python 3.6 and removed in 3.12 so, don't pass those to
+        # HTTPSConnection.__init__() --
+        # The SSL context with the client cert is built in connect() instead.
+        HTTPSConnection.__init__(self, host)
         self.key_file = key_file
         self.cert_file = cert_file
         self.ca_file = ca_file
@@ -251,14 +253,22 @@ class HTTPSCertConnection(HTTPSConnection):
         if self._tunnel_host:
             self.sock = sock
             self._tunnel()
-        context = ssl.SSLContext()
-        context.load_cert_chain( certfile=self.cert_file, keyfile=self.key_file )
-        # If there's no CA File, don't force Server Certificate Check
-        context.verify_mode = ssl.CERT_NONE
+        # empty call ssl.SSLContext() is deprecated since 3.10, thus handle is properly
+        # with PROTOCOL_TLS_CLIENT defaulting to check_hostname=True and
+        # verify_mode=CERT_REQUIRED.
+        # When no CA file is provided we disable server-certificate verification
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        context.load_cert_chain(certfile=self.cert_file, keyfile=self.key_file)
         if self.ca_file:
-            context.verify_mode = ssl.CERT_REQUIRED
-            context.load_verify_locations( ca_certs=self.ca_file )
-        self.sock = context.wrap_socket( sock )
+            # Server certificate verification enabled, below settings are defaults:
+            # (check_hostname=True, verify_mode=CERT_REQUIRED)
+            context.load_verify_locations(ca_certs=self.ca_file)
+        else:
+            # No CA file supplied: disable server certificate verification.
+            # check_hostname must be cleared before verify_mode can be set
+            context.check_hostname = False
+            context.verify_mode = ssl.CERT_NONE
+        self.sock = context.wrap_socket(sock, server_hostname=self.host)
 
 
 class EapiConnection(object):
@@ -558,7 +568,7 @@ class EapiConnection(object):
     def _parse_error_message(self, message):
         """Parses the eAPI failure response message
 
-        This method accepts an eAPI failure message and parses the necesary
+        This method accepts an eAPI failure message and parses the necessary
         parts in order to generate a CommandError.
 
         Args:
@@ -612,7 +622,7 @@ class EapiConnection(object):
             CommandError:  A CommandError is raised that includes the error
                 code, error message along with the list of commands that were
                 sent to the node.  The exception instance is also stored in
-                the error property and is availble until the next request is
+                the error property and is available until the next request is
                 sent
         """
         if encoding not in ('json', 'text'):

--- a/test/unit/test_eapilib.py
+++ b/test/unit/test_eapilib.py
@@ -1,7 +1,6 @@
 import unittest
 import json
 import ssl
-import socket
 
 from unittest.mock import Mock, patch, MagicMock, call
 
@@ -272,7 +271,7 @@ class TestHTTPSCertConnection(unittest.TestCase):
         HTTPSConnection.__init__(), which removed those parameters in 3.12.
         """
         try:
-            conn = pyeapi.eapilib.HTTPSCertConnection(
+            _ = pyeapi.eapilib.HTTPSCertConnection(
                 path='/command-api',
                 host='switch1',
                 port=443,
@@ -290,7 +289,7 @@ class TestHTTPSCertConnection(unittest.TestCase):
     def test_init_key_cert_not_forwarded_to_https_connection(self):
         """HTTPSConnection.__init__() must be called WITHOUT key_file/cert_file."""
         with patch('pyeapi.eapilib.HTTPSConnection.__init__',
-                   return_value=None) as mock_super_init:
+                   return_value=None):
             # Provide the minimum attributes that HTTPSConnection normally sets
             # so that our __init__ can complete without AttributeError.
             conn = pyeapi.eapilib.HTTPSCertConnection.__new__(

--- a/test/unit/test_eapilib.py
+++ b/test/unit/test_eapilib.py
@@ -296,8 +296,8 @@ class TestHTTPSCertConnection(unittest.TestCase):
             conn = pyeapi.eapilib.HTTPSCertConnection.__new__(
                 pyeapi.eapilib.HTTPSCertConnection)
             # Manually call __init__ via the class (bypasses MRO issues)
-            with patch.object(pyeapi.eapilib.HTTPSConnection, '__init__',
-                               return_value=None) as mock_init:
+            with patch.object(
+                    pyeapi.eapilib.HTTPSConnection, '__init__', return_value=None) as mock_init:
                 # Patch out attribute access that HTTPSConnection normally sets
                 conn.__dict__.update({
                     'key_file': None, 'cert_file': None, 'ca_file': None,
@@ -315,12 +315,14 @@ class TestHTTPSCertConnection(unittest.TestCase):
                 )
                 # The super().__init__() call must NOT include key_file or cert_file
                 args, kwargs = mock_init.call_args
-                self.assertNotIn('key_file', kwargs,
-                                 'key_file must not be passed to '
-                                 'HTTPSConnection.__init__()')
-                self.assertNotIn('cert_file', kwargs,
-                                 'cert_file must not be passed to '
-                                 'HTTPSConnection.__init__()')
+                self.assertNotIn(
+                    'key_file', kwargs,
+                    'key_file must not be passed to '
+                    'HTTPSConnection.__init__()')
+                self.assertNotIn(
+                    'cert_file', kwargs,
+                    'cert_file must not be passed to '
+                    'HTTPSConnection.__init__()')
 
     def test_str_and_repr(self):
         """__str__ and __repr__ must include host, port, path, key and cert."""

--- a/test/unit/test_eapilib.py
+++ b/test/unit/test_eapilib.py
@@ -1,7 +1,9 @@
 import unittest
 import json
+import ssl
+import socket
 
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, patch, MagicMock, call
 
 import pyeapi.eapilib
 
@@ -225,6 +227,365 @@ class TestEapiConnection(unittest.TestCase):
                                    unknown=True)
         data = json.loads(request)
         self.assertNotIn('unknown', data['params'])
+
+
+class TestHTTPSCertConnection(unittest.TestCase):
+    """Unit tests for HTTPSCertConnection (issue #318 fix).
+
+    Verifies that:
+      - key_file / cert_file are NOT forwarded to HTTPSConnection.__init__()
+        (those parameters were removed in Python 3.12).
+      - connect() builds an ssl.SSLContext using PROTOCOL_TLS_CLIENT and
+        loads the client certificate via load_cert_chain().
+      - When ca_file is provided, load_verify_locations() is called and
+        server-certificate verification stays enabled.
+      - When ca_file is None, check_hostname is disabled and verify_mode is
+        set to CERT_NONE.
+    """
+
+    # ------------------------------------------------------------------ #
+    # __init__ tests                                                       #
+    # ------------------------------------------------------------------ #
+
+    def test_init_stores_key_and_cert_as_attributes(self):
+        """key_file and cert_file must be stored as instance attributes."""
+        conn = pyeapi.eapilib.HTTPSCertConnection(
+            path='/command-api',
+            host='switch1',
+            port=443,
+            key_file='/path/to/client.key',
+            cert_file='/path/to/client.crt',
+            ca_file=None,
+            timeout=30,
+        )
+        self.assertEqual(conn.key_file, '/path/to/client.key')
+        self.assertEqual(conn.cert_file, '/path/to/client.crt')
+        self.assertIsNone(conn.ca_file)
+        self.assertEqual(conn.timeout, 30)
+        self.assertEqual(conn.path, '/command-api')
+        self.assertEqual(conn.port, 443)
+
+    def test_init_does_not_raise_typeerror_on_python312(self):
+        """Instantiation must not raise TypeError on Python 3.12+.
+
+        Prior to the fix, key_file/cert_file were forwarded to
+        HTTPSConnection.__init__(), which removed those parameters in 3.12.
+        """
+        try:
+            conn = pyeapi.eapilib.HTTPSCertConnection(
+                path='/command-api',
+                host='switch1',
+                port=443,
+                key_file='/path/to/client.key',
+                cert_file='/path/to/client.crt',
+                ca_file=None,
+            )
+        except TypeError as exc:
+            self.fail(
+                'HTTPSCertConnection.__init__() raised TypeError '
+                '(key_file/cert_file must not be passed to '
+                'HTTPSConnection.__init__()): %s' % exc
+            )
+
+    def test_init_key_cert_not_forwarded_to_https_connection(self):
+        """HTTPSConnection.__init__() must be called WITHOUT key_file/cert_file."""
+        with patch('pyeapi.eapilib.HTTPSConnection.__init__',
+                   return_value=None) as mock_super_init:
+            # Provide the minimum attributes that HTTPSConnection normally sets
+            # so that our __init__ can complete without AttributeError.
+            conn = pyeapi.eapilib.HTTPSCertConnection.__new__(
+                pyeapi.eapilib.HTTPSCertConnection)
+            # Manually call __init__ via the class (bypasses MRO issues)
+            with patch.object(pyeapi.eapilib.HTTPSConnection, '__init__',
+                               return_value=None) as mock_init:
+                # Patch out attribute access that HTTPSConnection normally sets
+                conn.__dict__.update({
+                    'key_file': None, 'cert_file': None, 'ca_file': None,
+                    'timeout': None, 'path': None, 'port': None,
+                    'host': 'switch1',
+                })
+                pyeapi.eapilib.HTTPSCertConnection.__init__(
+                    conn,
+                    path='/command-api',
+                    host='switch1',
+                    port=443,
+                    key_file='/path/to/client.key',
+                    cert_file='/path/to/client.crt',
+                    ca_file=None,
+                )
+                # The super().__init__() call must NOT include key_file or cert_file
+                args, kwargs = mock_init.call_args
+                self.assertNotIn('key_file', kwargs,
+                                 'key_file must not be passed to '
+                                 'HTTPSConnection.__init__()')
+                self.assertNotIn('cert_file', kwargs,
+                                 'cert_file must not be passed to '
+                                 'HTTPSConnection.__init__()')
+
+    def test_str_and_repr(self):
+        """__str__ and __repr__ must include host, port, path, key and cert."""
+        conn = pyeapi.eapilib.HTTPSCertConnection(
+            path='/command-api',
+            host='switch1',
+            port=443,
+            key_file='/path/to/client.key',
+            cert_file='/path/to/client.crt',
+            ca_file=None,
+        )
+        expected = 'https://switch1:443//command-api - /path/to/client.key,/path/to/client.crt'
+        self.assertEqual(str(conn), expected)
+        self.assertEqual(repr(conn), expected)
+
+    # ------------------------------------------------------------------ #
+    # connect() tests                                                      #
+    # ------------------------------------------------------------------ #
+
+    @patch('pyeapi.eapilib.ssl.SSLContext')
+    @patch('pyeapi.eapilib.socket.create_connection')
+    def test_connect_uses_protocol_tls_client(self, mock_create_conn,
+                                              mock_ssl_context_cls):
+        """connect() must create an SSLContext with PROTOCOL_TLS_CLIENT.
+
+        Note: HTTPSConnection.__init__() in Python 3.12 also calls
+        ssl.SSLContext() internally, so the mock may be invoked more than once.
+        We verify that at least one call used PROTOCOL_TLS_CLIENT.
+        """
+        mock_sock = Mock()
+        mock_create_conn.return_value = mock_sock
+        mock_context = MagicMock()
+        mock_ssl_context_cls.return_value = mock_context
+        mock_context.wrap_socket.return_value = Mock()
+
+        conn = pyeapi.eapilib.HTTPSCertConnection(
+            path='/command-api',
+            host='switch1',
+            port=443,
+            key_file='/path/to/client.key',
+            cert_file='/path/to/client.crt',
+            ca_file=None,
+        )
+        conn._tunnel_host = None
+        conn.connect()
+
+        # At least one call to ssl.SSLContext() must use PROTOCOL_TLS_CLIENT
+        # (HTTPSConnection.__init__ may also call SSLContext internally in 3.12)
+        calls_with_tls_client = [
+            c for c in mock_ssl_context_cls.call_args_list
+            if c == call(ssl.PROTOCOL_TLS_CLIENT)
+        ]
+        self.assertTrue(
+            len(calls_with_tls_client) >= 1,
+            'ssl.SSLContext(PROTOCOL_TLS_CLIENT) was not called by connect(). '
+            'Actual calls: %s' % mock_ssl_context_cls.call_args_list
+        )
+
+    @patch('pyeapi.eapilib.ssl.SSLContext')
+    @patch('pyeapi.eapilib.socket.create_connection')
+    def test_connect_loads_cert_chain(self, mock_create_conn,
+                                     mock_ssl_context_cls):
+        """connect() must call load_cert_chain() with cert_file and key_file."""
+        mock_sock = Mock()
+        mock_create_conn.return_value = mock_sock
+        mock_context = MagicMock()
+        mock_ssl_context_cls.return_value = mock_context
+        mock_context.wrap_socket.return_value = Mock()
+
+        conn = pyeapi.eapilib.HTTPSCertConnection(
+            path='/command-api',
+            host='switch1',
+            port=443,
+            key_file='/path/to/client.key',
+            cert_file='/path/to/client.crt',
+            ca_file=None,
+        )
+        conn._tunnel_host = None
+        conn.connect()
+
+        mock_context.load_cert_chain.assert_called_once_with(
+            certfile='/path/to/client.crt',
+            keyfile='/path/to/client.key',
+        )
+
+    @patch('pyeapi.eapilib.ssl.SSLContext')
+    @patch('pyeapi.eapilib.socket.create_connection')
+    def test_connect_without_ca_file_disables_verification(
+            self, mock_create_conn, mock_ssl_context_cls):
+        """When ca_file is None, server-cert verification must be disabled.
+
+        check_hostname must be set to False and verify_mode to CERT_NONE.
+        load_verify_locations() must NOT be called.
+        """
+        mock_sock = Mock()
+        mock_create_conn.return_value = mock_sock
+        mock_context = MagicMock()
+        mock_ssl_context_cls.return_value = mock_context
+        mock_context.wrap_socket.return_value = Mock()
+
+        conn = pyeapi.eapilib.HTTPSCertConnection(
+            path='/command-api',
+            host='switch1',
+            port=443,
+            key_file='/path/to/client.key',
+            cert_file='/path/to/client.crt',
+            ca_file=None,
+        )
+        conn._tunnel_host = None
+        conn.connect()
+
+        self.assertFalse(mock_context.check_hostname)
+        self.assertEqual(mock_context.verify_mode, ssl.CERT_NONE)
+        mock_context.load_verify_locations.assert_not_called()
+
+    @patch('pyeapi.eapilib.ssl.SSLContext')
+    @patch('pyeapi.eapilib.socket.create_connection')
+    def test_connect_with_ca_file_enables_verification(
+            self, mock_create_conn, mock_ssl_context_cls):
+        """When ca_file is provided, load_verify_locations() must be called.
+
+        check_hostname and verify_mode must keep their PROTOCOL_TLS_CLIENT
+        defaults — i.e. the code must NOT set check_hostname=False or
+        verify_mode=CERT_NONE when a CA file is supplied.
+        """
+        mock_sock = Mock()
+        mock_create_conn.return_value = mock_sock
+        mock_context = MagicMock()
+        mock_ssl_context_cls.return_value = mock_context
+        mock_context.wrap_socket.return_value = Mock()
+
+        conn = pyeapi.eapilib.HTTPSCertConnection(
+            path='/command-api',
+            host='switch1',
+            port=443,
+            key_file='/path/to/client.key',
+            cert_file='/path/to/client.crt',
+            ca_file='/path/to/ca.crt',
+        )
+        conn._tunnel_host = None
+        conn.connect()
+
+        # load_verify_locations must be called with the CA file
+        mock_context.load_verify_locations.assert_called_once_with(
+            ca_certs='/path/to/ca.crt'
+        )
+        # When ca_file is set, check_hostname must NOT be set to False and
+        # verify_mode must NOT be set to CERT_NONE.
+        # We verify this by inspecting the mock's recorded attribute writes.
+        # MagicMock stores attribute assignments in _mock_children / mock_calls;
+        # the simplest reliable check is that check_hostname was never assigned
+        # False and verify_mode was never assigned CERT_NONE.
+        for mc in mock_context.mock_calls:
+            mc_str = str(mc)
+            self.assertNotIn('check_hostname = False', mc_str)
+            self.assertNotIn('verify_mode = 0', mc_str)   # ssl.CERT_NONE == 0
+
+    @patch('pyeapi.eapilib.ssl.SSLContext')
+    @patch('pyeapi.eapilib.socket.create_connection')
+    def test_connect_wraps_socket_with_server_hostname(
+            self, mock_create_conn, mock_ssl_context_cls):
+        """connect() must call wrap_socket() with server_hostname=host."""
+        mock_sock = Mock()
+        mock_create_conn.return_value = mock_sock
+        mock_context = MagicMock()
+        mock_ssl_context_cls.return_value = mock_context
+        wrapped = Mock()
+        mock_context.wrap_socket.return_value = wrapped
+
+        conn = pyeapi.eapilib.HTTPSCertConnection(
+            path='/command-api',
+            host='switch1',
+            port=443,
+            key_file='/path/to/client.key',
+            cert_file='/path/to/client.crt',
+            ca_file=None,
+        )
+        conn._tunnel_host = None
+        conn.connect()
+
+        mock_context.wrap_socket.assert_called_once_with(
+            mock_sock, server_hostname='switch1'
+        )
+        self.assertIs(conn.sock, wrapped)
+
+    @patch('pyeapi.eapilib.ssl.SSLContext')
+    @patch('pyeapi.eapilib.socket.create_connection')
+    def test_connect_creates_connection_to_correct_host_port(
+            self, mock_create_conn, mock_ssl_context_cls):
+        """connect() must open a TCP connection to (host, port)."""
+        mock_sock = Mock()
+        mock_create_conn.return_value = mock_sock
+        mock_context = MagicMock()
+        mock_ssl_context_cls.return_value = mock_context
+        mock_context.wrap_socket.return_value = Mock()
+
+        conn = pyeapi.eapilib.HTTPSCertConnection(
+            path='/command-api',
+            host='switch1',
+            port=8443,
+            key_file='/path/to/client.key',
+            cert_file='/path/to/client.crt',
+            ca_file=None,
+            timeout=15,
+        )
+        conn._tunnel_host = None
+        conn.connect()
+
+        mock_create_conn.assert_called_once_with(('switch1', 8443), 15)
+
+
+class TestHttpsEapiCertConnection(unittest.TestCase):
+    """Unit tests for HttpsEapiCertConnection (issue #318 fix)."""
+
+    def test_raises_value_error_when_key_file_missing(self):
+        """Must raise ValueError when key_file is not provided."""
+        with self.assertRaises(ValueError):
+            pyeapi.eapilib.HttpsEapiCertConnection(
+                host='switch1',
+                cert_file='/path/to/client.crt',
+            )
+
+    def test_raises_value_error_when_cert_file_missing(self):
+        """Must raise ValueError when cert_file is not provided."""
+        with self.assertRaises(ValueError):
+            pyeapi.eapilib.HttpsEapiCertConnection(
+                host='switch1',
+                key_file='/path/to/client.key',
+            )
+
+    def test_raises_value_error_when_both_files_missing(self):
+        """Must raise ValueError when neither key_file nor cert_file is given."""
+        with self.assertRaises(ValueError):
+            pyeapi.eapilib.HttpsEapiCertConnection(host='switch1')
+
+    def test_creates_https_cert_connection_transport(self):
+        """Transport must be an HTTPSCertConnection instance."""
+        instance = pyeapi.eapilib.HttpsEapiCertConnection(
+            host='switch1',
+            key_file='/path/to/client.key',
+            cert_file='/path/to/client.crt',
+        )
+        self.assertIsInstance(instance.transport,
+                              pyeapi.eapilib.HTTPSCertConnection)
+
+    def test_transport_stores_key_and_cert(self):
+        """Transport must expose the key_file and cert_file passed in."""
+        instance = pyeapi.eapilib.HttpsEapiCertConnection(
+            host='switch1',
+            key_file='/path/to/client.key',
+            cert_file='/path/to/client.crt',
+            ca_file='/path/to/ca.crt',
+        )
+        self.assertEqual(instance.transport.key_file, '/path/to/client.key')
+        self.assertEqual(instance.transport.cert_file, '/path/to/client.crt')
+        self.assertEqual(instance.transport.ca_file, '/path/to/ca.crt')
+
+    def test_is_eapi_connection_instance(self):
+        """HttpsEapiCertConnection must be an EapiConnection subclass."""
+        instance = pyeapi.eapilib.HttpsEapiCertConnection(
+            host='switch1',
+            key_file='/path/to/client.key',
+            cert_file='/path/to/client.crt',
+        )
+        self.assertIsInstance(instance, pyeapi.eapilib.EapiConnection)
 
 
 class TestCommandError(unittest.TestCase):


### PR DESCRIPTION
fix for the issue #318, plus a deprecation for an empty `ssl.SSLContext()` call