### PR TITLE
fix for the issue #320

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,6 +8,7 @@ include *.yaml
 recursive-include examples *.conf
 recursive-include examples *.py
 recursive-include test *.conf
+recursive-include test *.code_unit
 recursive-include test *.json
 recursive-include test *.portchannel
 recursive-include test *.py

--- a/pyeapi/client.py
+++ b/pyeapi/client.py
@@ -717,27 +717,47 @@ class Node(object):
         indent > 0, then it's a recursive call and `config` argument contains
         last parsed (sub)section, which in turn may contain sub-sections
         """
-        def is_subsection_present( section, indent ):
-            return any( line[ indent ] == ' ' for line in section )
+        def is_subsection_present( section, indent, section_key ):
+            for line in section:
+                if len( line ) <= indent:
+                    raise ValueError(
+                        f'Unable to parse section {section_key!r} at indent '
+                        f'{indent} due to short line {line!r}; likely '
+                        'unhandled multiline literal block (EOF-terminated)'
+                    )
+                if line[ indent ] == ' ':
+                    return True
+            return False
 
         def get_indent( line ):
             return len( line ) - len( line.lstrip() )
 
         sections = {}
         key = None
-        banner = None
+        multiline = None
         for line in config.splitlines( keepends=True )[ indent > 0: ]:
             line_rs = line.rstrip()
-            if indent == 0:
-                if banner:
-                    sections[ banner ] += line
-                    if line_rs == 'EOF':
-                        banner = None
-                    continue
-                if line.startswith( 'banner ' ):
-                    banner = line_rs
-                    sections[ banner ] = line
-                    continue
+
+            if multiline:
+                sections[ multiline ] += line
+                if line_rs == 'EOF':
+                    multiline = None
+                continue
+
+            if indent == 0 and line.startswith( 'banner ' ):
+                multiline = line_rs
+                sections[ multiline ] = line
+                continue
+
+            if line_rs.lstrip().startswith( 'code unit ' ):
+                if key is None:
+                    key = line_rs
+                    sections[ key ] = line
+                else:
+                    sections[ key ] += line
+                multiline = key
+                continue
+
             if get_indent( line_rs ) > indent:  # i.e. subsection line
                 # key is always expected to be set by now
                 sections[ key ] += line
@@ -745,7 +765,7 @@ class Node(object):
             subsection = sections.get( key, '' ).splitlines()[ 1: ]
             if subsection:
                 sub_indent = get_indent( subsection[0] )
-                if is_subsection_present( subsection, sub_indent ):
+                if is_subsection_present( subsection, sub_indent, key ):
                     parsed = self._chunkify( sections[key], indent=sub_indent )
                     parsed.update( sections )
                     sections = parsed

--- a/test/fixtures/running_config.code_unit
+++ b/test/fixtures/running_config.code_unit
@@ -1,0 +1,19 @@
+router bgp 43902
+   router-id 1.1.1.1
+!
+router general
+   control-functions
+      code unit REDISTRIBUTE_STATIC_BGP_POLICIES
+               function STATIC_TO_BGP() {
+                     if igp.tag is 10 {
+                  
+                       community = {
+                     5405:65531,
+                     5405:65533,
+                     5405:65532
+                   };
+                 }
+               }
+      EOF
+   !
+!

--- a/test/unit/test_client.py
+++ b/test/unit/test_client.py
@@ -221,6 +221,26 @@ class TestNode(unittest.TestCase):
         with self.assertRaises(TypeError):
             self.node.enable(cmds)
 
+    def test_chunkify_supports_code_unit_multiline_blocks(self):
+        with open(get_fixture('running_config.code_unit')) as config_file:
+            config = config_file.read()
+
+        sections = self.node._chunkify(config)
+        self.assertIn('router bgp 43902', sections)
+
+    def test_chunkify_raises_for_unknown_multiline_literal_blocks(self):
+        config = ('router test\n'
+                  '   alpha\n'
+                  '      unknown literal start\n'
+                  '            nested content\n'
+                  '         \n'
+                  '      END\n'
+                  '   !\n'
+                  '!\n')
+
+        with self.assertRaises(ValueError):
+            self.node._chunkify(config)
+
 
 class TestClient(unittest.TestCase):
 


### PR DESCRIPTION
Added fix for the issue #320:
- handling (skip parsing) `code unit` block same was as the `banner` section
- elevated the case when another block requiring a similar handling is discovered (with a better message)
- updated UT

UT passed, the config in the issue works fine now.